### PR TITLE
369088 - Provide an option to enable tolerations and affinity in Bold BI Helm chart

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -180,6 +180,42 @@ For Helm chart, you'll need to craft a `values.yaml`.
        Integrating Azure Application Insights with Bold BI Enterprise Edition enables you to track and visualize your application’s performance, detect issues, and enhance your application’s overall reliability.
       </td>
     </tr>
+        <tr>
+      <td>
+       tolerationEnable:<br />
+       tolerations:
+      </td>
+      <td>
+       Tolerations allow the pods to be scheduled onto nodes with matching taints.Set this to true if you have use tolerations in your cluster.If you need more than one toleration, you can add tolerations below.
+      </td>
+    </tr>
+        <tr>
+      <td>
+       nodeAffinity:<br />
+         nodeAffinityEnable:
+      </td>
+      <td>
+       Node affinity ensures that the pods are scheduled onto nodes with matching labels. Set this to true if you have use Node affinity in your cluster.
+      </td>
+    </tr>
+        <tr>
+      <td>
+       podAffinity:<br />
+         podAffinityEnable:
+      </td>
+      <td>
+        Pod affinity ensures that the pods are scheduled onto nodes with matching pods.Set this to true if you have use pod Affinity in your cluster.
+      </td>
+    </tr>
+        <tr>
+      <td>
+       podAntiAffinity:<br />
+         podAntiAffinityEnable:
+      </td>
+      <td>
+        Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.Set this to true if you have use pod AntiAffinity in your cluster.
+      </td>
+    </tr>
     </table>
 <br/>
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -182,7 +182,7 @@ For Helm chart, you'll need to craft a `values.yaml`.
     </tr>
         <tr>
       <td>
-       tolerationEnable:<br />
+       tolerationEnable: false<br />
        tolerations:
       </td>
       <td>
@@ -191,8 +191,8 @@ For Helm chart, you'll need to craft a `values.yaml`.
     </tr>
         <tr>
       <td>
-       nodeAffinity:<br />
-         nodeAffinityEnable:
+       nodeAffinityEnable: false<br />
+       nodeAffinity:
       </td>
       <td>
        Node affinity ensures that the pods are scheduled onto nodes with matching labels. Set this to true if you have use Node affinity in your cluster.
@@ -200,8 +200,7 @@ For Helm chart, you'll need to craft a `values.yaml`.
     </tr>
         <tr>
       <td>
-       podAffinity:<br />
-         podAffinityEnable:
+         podAffinityEnable: false
       </td>
       <td>
         Pod affinity ensures that the pods are scheduled onto nodes with matching pods.Set this to true if you have use pod Affinity in your cluster.
@@ -209,8 +208,7 @@ For Helm chart, you'll need to craft a `values.yaml`.
     </tr>
         <tr>
       <td>
-       podAntiAffinity:<br />
-         podAntiAffinityEnable:
+         podAntiAffinityEnable: false
       </td>
       <td>
         Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.Set this to true if you have use pod AntiAffinity in your cluster.

--- a/helm/README.md
+++ b/helm/README.md
@@ -186,7 +186,7 @@ For Helm chart, you'll need to craft a `values.yaml`.
        tolerations:
       </td>
       <td>
-       Tolerations allow the pods to be scheduled onto nodes with matching taints. Set this to true if you use tolerations in your cluster. If you need more than one toleration, you can add multiple tolerations below.
+       Tolerations allow the pods to be scheduled into nodes with matching taints. Set this to true if you use tolerations in your cluster. If you need more than one toleration, you can add multiple tolerations below.
       </td>
     </tr>
         <tr>
@@ -195,7 +195,7 @@ For Helm chart, you'll need to craft a `values.yaml`.
        nodeAffinity:
       </td>
       <td>
-       Node affinity ensures that the pods are scheduled onto nodes with matching labels. Set this to true if you use node affinity in your cluster.
+       Node affinity ensures that the pods are scheduled into nodes with matching labels. Set this to true if you use node affinity in your cluster.
       </td>
     </tr>
         <tr>
@@ -203,7 +203,7 @@ For Helm chart, you'll need to craft a `values.yaml`.
          podAffinityEnable: false
       </td>
       <td>
-        Pod affinity ensures that the pods are scheduled onto nodes with matching pods. Set this to true if you use pod affinity in your cluster
+        Pod affinity ensures that the pods are scheduled into nodes with matching pods. Set this to true if you use pod affinity in your cluster
       </td>
     </tr>
         <tr>
@@ -211,7 +211,7 @@ For Helm chart, you'll need to craft a `values.yaml`.
          podAntiAffinityEnable: false
       </td>
       <td>
-        Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods. Set this to true if you use pod anti-affinity in your cluster.
+        Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods. Set this to true if you use pod anti-affinity in your cluster.
       </td>
     </tr>
     </table>

--- a/helm/README.md
+++ b/helm/README.md
@@ -186,7 +186,7 @@ For Helm chart, you'll need to craft a `values.yaml`.
        tolerations:
       </td>
       <td>
-       Tolerations allow the pods to be scheduled onto nodes with matching taints.Set this to true if you have use tolerations in your cluster.If you need more than one toleration, you can add tolerations below.
+       Tolerations allow the pods to be scheduled onto nodes with matching taints. Set this to true if you use tolerations in your cluster. If you need more than one toleration, you can add multiple tolerations below.
       </td>
     </tr>
         <tr>
@@ -195,7 +195,7 @@ For Helm chart, you'll need to craft a `values.yaml`.
        nodeAffinity:
       </td>
       <td>
-       Node affinity ensures that the pods are scheduled onto nodes with matching labels. Set this to true if you have use Node affinity in your cluster.
+       Node affinity ensures that the pods are scheduled onto nodes with matching labels. Set this to true if you use node affinity in your cluster.
       </td>
     </tr>
         <tr>
@@ -203,7 +203,7 @@ For Helm chart, you'll need to craft a `values.yaml`.
          podAffinityEnable: false
       </td>
       <td>
-        Pod affinity ensures that the pods are scheduled onto nodes with matching pods.Set this to true if you have use pod Affinity in your cluster.
+        Pod affinity ensures that the pods are scheduled onto nodes with matching pods. Set this to true if you use pod affinity in your cluster
       </td>
     </tr>
         <tr>
@@ -211,7 +211,7 @@ For Helm chart, you'll need to craft a `values.yaml`.
          podAntiAffinityEnable: false
       </td>
       <td>
-        Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.Set this to true if you have use pod AntiAffinity in your cluster.
+        Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods. Set this to true if you use pod anti-affinity in your cluster.
       </td>
     </tr>
     </table>

--- a/helm/bold-common/templates/deployment.yaml
+++ b/helm/bold-common/templates/deployment.yaml
@@ -194,9 +194,9 @@ spec:
           effect: "{{ .effect }}"
         {{- end }}
       {{- end }}
-      {{- if or $.Values.nodeAffinity.nodeAffinityEnable $.Values.podAffinity.podAffinityEnable $.Values.podAntiAffinity.podAntiAffinityEnable}}
+      {{- if or $.Values.nodeAffinityEnable $.Values.podAffinityEnable $.Values.podAntiAffinityEnable}}
       affinity:
-        {{- if $.Values.nodeAffinity.nodeAffinityEnable }}
+        {{- if $.Values.nodeAffinityEnable }}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -206,7 +206,7 @@ spec:
                 values:
                 - "{{ $.Values.nodeAffinity.value }}"
         {{- end }} 
-        {{- if $.Values.podAffinity.podAffinityEnable }}
+        {{- if $.Values.podAffinityEnable }}
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -217,7 +217,7 @@ spec:
                 - "{{ $service.app }}"
             topologyKey: "kubernetes.io/hostname"
         {{- end }}
-        {{- if $.Values.podAntiAffinity.podAntiAffinityEnable }}
+        {{- if $.Values.podAntiAffinityEnable }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/helm/bold-common/templates/deployment.yaml
+++ b/helm/bold-common/templates/deployment.yaml
@@ -183,5 +183,51 @@ spec:
       - name: log4net-config-volume
         configMap:
           name: log4net-config
+      {{- if $.Values.tolerationEnable }}
+      tolerations:
+        {{- range $.Values.tolerations }}
+        - key: "{{ .key }}"
+          operator: "{{ .operator }}"
+          {{- if .value }}
+          value: "{{ .value }}"
+          {{- end }}
+          effect: "{{ .effect }}"
+        {{- end }}
+      {{- end }}
+      {{- if or $.Values.nodeAffinity.nodeAffinityEnable $.Values.podAffinity.podAffinityEnable $.Values.podAntiAffinity.podAntiAffinityEnable}}
+      affinity:
+        {{- if $.Values.nodeAffinity.nodeAffinityEnable }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "{{ $.Values.nodeAffinity.key }}"
+                operator: "{{ $.Values.nodeAffinity.operator }}"
+                values:
+                - "{{ $.Values.nodeAffinity.value }}"
+        {{- end }} 
+        {{- if $.Values.podAffinity.podAffinityEnable }}
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "app.kubernetes.io/name" 
+                operator: "In"
+                values:
+                - "{{ $service.app }}"
+            topologyKey: "kubernetes.io/hostname"
+        {{- end }}
+        {{- if $.Values.podAntiAffinity.podAntiAffinityEnable }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "app.kubernetes.io/name" 
+                operator: "In"
+                values:
+                - "{{ $service.app }}"
+            topologyKey: "kubernetes.io/hostname"   
+        {{- end }}                
+      {{- end }}
 ---
 {{- end }}

--- a/helm/bold-common/values.yaml
+++ b/helm/bold-common/values.yaml
@@ -279,7 +279,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true
+tolerationEnable: false
 tolerations:
   - key: ""
     operator: ""
@@ -289,7 +289,7 @@ tolerations:
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
-  nodeAffinityEnable: true
+  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
@@ -297,9 +297,9 @@ nodeAffinity:
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: true
+  podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
-  podAntiAffinityEnable: true
+  podAntiAffinityEnable: false

--- a/helm/bold-common/values.yaml
+++ b/helm/bold-common/values.yaml
@@ -275,3 +275,31 @@ queryMetricsInDebugFiles:
 ## If the query and query metrics need to be logged in debug files, set this option to true. By default, this option is set to false.
 queryMetricsWithQueryInDebugFiles:
   enable: false
+
+# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Set this to true if you have use tolerations in your cluster.
+# If you need more than one toleration, you can add tolerations below.
+tolerationEnable: true
+tolerations:
+  - key: ""
+    operator: ""
+    value: ""
+    effect: ""
+
+# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Set this to true if you have use Node affinity in your cluster.
+nodeAffinity:
+  nodeAffinityEnable: true
+  key: ""
+  operator: ""
+  value: ""
+
+# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Set this to true if you have use pod Affinity in your cluster.
+podAffinity:
+  podAffinityEnable: true
+
+# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Set this to true if you have use pod AntiAffinity in your cluster.
+podAntiAffinity:
+  podAntiAffinityEnable: true

--- a/helm/bold-common/values.yaml
+++ b/helm/bold-common/values.yaml
@@ -277,7 +277,7 @@ queryMetricsWithQueryInDebugFiles:
   enable: false
 
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
-# Set this to true if you have use tolerations in your cluster.
+# Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
 tolerations:
@@ -287,7 +287,7 @@ tolerations:
     effect: ""
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
-# Set this to true if you have use Node affinity in your cluster.
+# Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
   key: ""
@@ -295,9 +295,9 @@ nodeAffinity:
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
-# Set this to true if you have use pod Affinity in your cluster.
+# Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
-# Set this to true if you have use pod AntiAffinity in your cluster.
+# Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/bold-common/values.yaml
+++ b/helm/bold-common/values.yaml
@@ -279,7 +279,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: false
+tolerationEnable: true 
 tolerations:
   - key: ""
     operator: ""
@@ -288,18 +288,16 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
+nodeAffinityEnable: true
 nodeAffinity:
-  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinity:
-  podAffinityEnable: false
+podAffinityEnable: true
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinity:
-  podAntiAffinityEnable: false
+podAntiAffinityEnable: true

--- a/helm/bold-common/values.yaml
+++ b/helm/bold-common/values.yaml
@@ -279,7 +279,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true 
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -288,7 +288,7 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
-nodeAffinityEnable: true
+nodeAffinityEnable: false
 nodeAffinity:
   key: ""
   operator: ""
@@ -296,8 +296,8 @@ nodeAffinity:
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinityEnable: true
+podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinityEnable: true
+podAntiAffinityEnable: false

--- a/helm/bold-common/values.yaml
+++ b/helm/bold-common/values.yaml
@@ -276,7 +276,7 @@ queryMetricsInDebugFiles:
 queryMetricsWithQueryInDebugFiles:
   enable: false
 
-# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
@@ -286,7 +286,7 @@ tolerations:
     value: ""
     effect: ""
 
-# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Node affinity ensures that the pods are scheduled into nodes with matching labels.
 # Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
@@ -294,10 +294,10 @@ nodeAffinity:
   operator: ""
   value: ""
 
-# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Pod affinity ensures that the pods are scheduled into nodes with matching pods.
 # Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
-# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods.
 # Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/boldbi/templates/deployment.yaml
+++ b/helm/boldbi/templates/deployment.yaml
@@ -174,7 +174,7 @@ spec:
         value: "{{ $.Values.tolerations.value }}"
         effect: "{{ $.Values.tolerations.effect }}"
       {{- end }}
-      {{- if or $.Values.nodeAffinity.nodeAffinityEnable $.Values.podAffinity.podAffinityEnable }}
+      {{- if or $.Values.nodeAffinity.nodeAffinityEnable $.Values.podAffinity.podAffinityEnable $.Values.podAntiAffinity.podAntiAffinityEnable}}
       affinity:
         {{- if $.Values.nodeAffinity.nodeAffinityEnable }}
         nodeAffinity:
@@ -191,10 +191,10 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: "{{ $.Values.nodeAffinity.key }}"
-                operator: "{{ $.Values.nodeAffinity.operator }}"
+              - key: "app.kubernetes.io/name" 
+                operator: "In"
                 values:
-                - "{{ $.Values.nodeAffinity.value }}"
+                - "{{ $service.app }}"
             topologyKey: "kubernetes.io/hostname"
         {{- end }}
         {{- if $.Values.podAntiAffinity.podAntiAffinityEnable }}
@@ -202,10 +202,10 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: "{{ $.Values.podAntiAffinity.key }}"
-                operator: "{{ $.Values.podAntiAffinity.operator }}"
+              - key: "app.kubernetes.io/name" 
+                operator: "In"
                 values:
-                - "{{ $.Values.podAntiAffinity.value }}"
+                - "{{ $service.app }}"
             topologyKey: "kubernetes.io/hostname"   
         {{- end }}                
       {{- end }}      

--- a/helm/boldbi/templates/deployment.yaml
+++ b/helm/boldbi/templates/deployment.yaml
@@ -178,9 +178,9 @@ spec:
           effect: "{{ .effect }}"
         {{- end }}
       {{- end }}
-      {{- if or $.Values.nodeAffinity.nodeAffinityEnable $.Values.podAffinity.podAffinityEnable $.Values.podAntiAffinity.podAntiAffinityEnable}}
+      {{- if or $.Values.nodeAffinityEnable $.Values.podAffinityEnable $.Values.podAntiAffinityEnable}}
       affinity:
-        {{- if $.Values.nodeAffinity.nodeAffinityEnable }}
+        {{- if $.Values.nodeAffinityEnable }}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -190,7 +190,7 @@ spec:
                 values:
                 - "{{ $.Values.nodeAffinity.value }}"
         {{- end }} 
-        {{- if $.Values.podAffinity.podAffinityEnable }}
+        {{- if $.Values.podAffinityEnable }}
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -201,7 +201,7 @@ spec:
                 - "{{ $service.app }}"
             topologyKey: "kubernetes.io/hostname"
         {{- end }}
-        {{- if $.Values.podAntiAffinity.podAntiAffinityEnable }}
+        {{- if $.Values.podAntiAffinityEnable }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/helm/boldbi/templates/deployment.yaml
+++ b/helm/boldbi/templates/deployment.yaml
@@ -167,5 +167,47 @@ spec:
       - name: log4net-config-volume
         configMap:
           name: log4net-config
+      {{- if $.Values.tolerations.tolerationEnable }}
+      tolerations:
+      - key: "{{ $.Values.tolerations.key }}"
+        operator: "{{ $.Values.tolerations.operator }}"
+        value: "{{ $.Values.tolerations.value }}"
+        effect: "{{ $.Values.tolerations.effect }}"
+      {{- end }}
+      {{- if or $.Values.nodeAffinity.nodeAffinityEnable $.Values.podAffinity.podAffinityEnable }}
+      affinity:
+        {{- if $.Values.nodeAffinity.nodeAffinityEnable }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "{{ $.Values.nodeAffinity.key }}"
+                operator: "{{ $.Values.nodeAffinity.operator }}"
+                values:
+                - "{{ $.Values.nodeAffinity.value }}"
+        {{- end }} 
+        {{- if $.Values.podAffinity.podAffinityEnable }}
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "{{ $.Values.nodeAffinity.key }}"
+                operator: "{{ $.Values.nodeAffinity.operator }}"
+                values:
+                - "{{ $.Values.nodeAffinity.value }}"
+            topologyKey: "kubernetes.io/hostname"
+        {{- end }}
+        {{- if $.Values.podAntiAffinity.podAntiAffinityEnable }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "{{ $.Values.podAntiAffinity.key }}"
+                operator: "{{ $.Values.podAntiAffinity.operator }}"
+                values:
+                - "{{ $.Values.podAntiAffinity.value }}"
+            topologyKey: "kubernetes.io/hostname"   
+        {{- end }}                
+      {{- end }}      
 ---
 {{- end }}

--- a/helm/boldbi/templates/deployment.yaml
+++ b/helm/boldbi/templates/deployment.yaml
@@ -167,12 +167,16 @@ spec:
       - name: log4net-config-volume
         configMap:
           name: log4net-config
-      {{- if $.Values.tolerations.tolerationEnable }}
+      {{- if $.Values.tolerationEnable }}
       tolerations:
-      - key: "{{ $.Values.tolerations.key }}"
-        operator: "{{ $.Values.tolerations.operator }}"
-        value: "{{ $.Values.tolerations.value }}"
-        effect: "{{ $.Values.tolerations.effect }}"
+        {{- range $.Values.tolerations }}
+        - key: "{{ .key }}"
+          operator: "{{ .operator }}"
+          {{- if .value }}
+          value: "{{ .value }}"
+          {{- end }}
+          effect: "{{ .effect }}"
+        {{- end }}
       {{- end }}
       {{- if or $.Values.nodeAffinity.nodeAffinityEnable $.Values.podAffinity.podAffinityEnable $.Values.podAntiAffinity.podAntiAffinityEnable}}
       affinity:

--- a/helm/boldbi/values.yaml
+++ b/helm/boldbi/values.yaml
@@ -237,3 +237,31 @@ licenseKeyDetails:
   
   # The Bold BI licnece key which you have purchesed.
   licenseKey: ""
+
+# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Set this to true if you have use tolerations in your cluster.
+# If you need more than one toleration, you can add tolerations below.
+tolerationEnable: true
+tolerations:
+  - key: ""
+    operator: ""
+    value: ""
+    effect: ""
+
+# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Set this to true if you have use Node affinity in your cluster.
+nodeAffinity:
+  nodeAffinityEnable: true
+  key: ""
+  operator: ""
+  value: ""
+
+# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Set this to true if you have use pod Affinity in your cluster.
+podAffinity:
+  podAffinityEnable: true
+
+# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Set this to true if you have use pod AntiAffinity in your cluster.
+podAntiAffinity:
+  podAntiAffinityEnable: true

--- a/helm/boldbi/values.yaml
+++ b/helm/boldbi/values.yaml
@@ -238,7 +238,7 @@ licenseKeyDetails:
   # The Bold BI licnece key which you have purchesed.
   licenseKey: ""
 
-# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
@@ -248,7 +248,7 @@ tolerations:
     value: ""
     effect: ""
 
-# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Node affinity ensures that the pods are scheduled into nodes with matching labels.
 # Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
@@ -256,10 +256,10 @@ nodeAffinity:
   operator: ""
   value: ""
 
-# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Pod affinity ensures that the pods are scheduled into nodes with matching pods.
 # Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
-# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods.
 # Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/boldbi/values.yaml
+++ b/helm/boldbi/values.yaml
@@ -239,7 +239,7 @@ licenseKeyDetails:
   licenseKey: ""
 
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
-# Set this to true if you have use tolerations in your cluster.
+# Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
 tolerations:
@@ -249,7 +249,7 @@ tolerations:
     effect: ""
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
-# Set this to true if you have use Node affinity in your cluster.
+# Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
   key: ""
@@ -257,9 +257,9 @@ nodeAffinity:
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
-# Set this to true if you have use pod Affinity in your cluster.
+# Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
-# Set this to true if you have use pod AntiAffinity in your cluster.
+# Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/boldbi/values.yaml
+++ b/helm/boldbi/values.yaml
@@ -241,7 +241,7 @@ licenseKeyDetails:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true
+tolerationEnable: false
 tolerations:
   - key: ""
     operator: ""
@@ -251,7 +251,7 @@ tolerations:
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
-  nodeAffinityEnable: true
+  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
@@ -259,9 +259,9 @@ nodeAffinity:
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: true
+  podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
-  podAntiAffinityEnable: true
+  podAntiAffinityEnable: false

--- a/helm/boldbi/values.yaml
+++ b/helm/boldbi/values.yaml
@@ -241,7 +241,7 @@ licenseKeyDetails:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: false
+tolerationEnable: true 
 tolerations:
   - key: ""
     operator: ""
@@ -250,18 +250,16 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
+nodeAffinityEnable: true
 nodeAffinity:
-  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinity:
-  podAffinityEnable: false
+podAffinityEnable: true
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinity:
-  podAntiAffinityEnable: false
+podAntiAffinityEnable: true

--- a/helm/boldbi/values.yaml
+++ b/helm/boldbi/values.yaml
@@ -241,7 +241,7 @@ licenseKeyDetails:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true 
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -250,7 +250,7 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
-nodeAffinityEnable: true
+nodeAffinityEnable: false
 nodeAffinity:
   key: ""
   operator: ""
@@ -258,8 +258,8 @@ nodeAffinity:
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinityEnable: true
+podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinityEnable: true
+podAntiAffinityEnable: false

--- a/helm/custom-values/Auto-deploy-values.yaml
+++ b/helm/custom-values/Auto-deploy-values.yaml
@@ -265,7 +265,7 @@ bingMapWidget:
   enabled: false
   apiKey: ''
 
-# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
@@ -275,7 +275,7 @@ tolerations:
     value: ""
     effect: ""
 
-# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Node affinity ensures that the pods are scheduled into nodes with matching labels.
 # Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
@@ -283,10 +283,10 @@ nodeAffinity:
   operator: ""
   value: ""
 
-# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Pod affinity ensures that the pods are scheduled into nodes with matching pods.
 # Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
-# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods.
 # Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/Auto-deploy-values.yaml
+++ b/helm/custom-values/Auto-deploy-values.yaml
@@ -264,3 +264,31 @@ bingMapWidget:
   bingMapSecretName: ''
   enabled: false
   apiKey: ''
+
+# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Set this to true if you have use tolerations in your cluster.
+# If you need more than one toleration, you can add tolerations below.
+tolerationEnable: true
+tolerations:
+  - key: ""
+    operator: ""
+    value: ""
+    effect: ""
+
+# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Set this to true if you have use Node affinity in your cluster.
+nodeAffinity:
+  nodeAffinityEnable: true
+  key: ""
+  operator: ""
+  value: ""
+
+# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Set this to true if you have use pod Affinity in your cluster.
+podAffinity:
+  podAffinityEnable: true
+
+# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Set this to true if you have use pod AntiAffinity in your cluster.
+podAntiAffinity:
+  podAntiAffinityEnable: true

--- a/helm/custom-values/Auto-deploy-values.yaml
+++ b/helm/custom-values/Auto-deploy-values.yaml
@@ -268,7 +268,7 @@ bingMapWidget:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true 
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -277,7 +277,7 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
-nodeAffinityEnable: true
+nodeAffinityEnable: false
 nodeAffinity:
   key: ""
   operator: ""
@@ -285,8 +285,8 @@ nodeAffinity:
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinityEnable: true
+podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinityEnable: true
+podAntiAffinityEnable: false

--- a/helm/custom-values/Auto-deploy-values.yaml
+++ b/helm/custom-values/Auto-deploy-values.yaml
@@ -266,7 +266,7 @@ bingMapWidget:
   apiKey: ''
 
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
-# Set this to true if you have use tolerations in your cluster.
+# Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
 tolerations:
@@ -276,7 +276,7 @@ tolerations:
     effect: ""
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
-# Set this to true if you have use Node affinity in your cluster.
+# Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
   key: ""
@@ -284,9 +284,9 @@ nodeAffinity:
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
-# Set this to true if you have use pod Affinity in your cluster.
+# Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
-# Set this to true if you have use pod AntiAffinity in your cluster.
+# Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/Auto-deploy-values.yaml
+++ b/helm/custom-values/Auto-deploy-values.yaml
@@ -268,7 +268,7 @@ bingMapWidget:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true
+tolerationEnable: false
 tolerations:
   - key: ""
     operator: ""
@@ -278,7 +278,7 @@ tolerations:
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
-  nodeAffinityEnable: true
+  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
@@ -286,9 +286,9 @@ nodeAffinity:
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: true
+  podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
-  podAntiAffinityEnable: true
+  podAntiAffinityEnable: false

--- a/helm/custom-values/Auto-deploy-values.yaml
+++ b/helm/custom-values/Auto-deploy-values.yaml
@@ -268,7 +268,7 @@ bingMapWidget:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: false
+tolerationEnable: true 
 tolerations:
   - key: ""
     operator: ""
@@ -277,18 +277,16 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
+nodeAffinityEnable: true
 nodeAffinity:
-  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinity:
-  podAffinityEnable: false
+podAffinityEnable: true
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinity:
-  podAntiAffinityEnable: false
+podAntiAffinityEnable: true

--- a/helm/custom-values/ack-values.yaml
+++ b/helm/custom-values/ack-values.yaml
@@ -221,7 +221,7 @@ licenseKeyDetails:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true 
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -230,7 +230,7 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
-nodeAffinityEnable: true
+nodeAffinityEnable: false
 nodeAffinity:
   key: ""
   operator: ""
@@ -238,8 +238,8 @@ nodeAffinity:
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinityEnable: true
+podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinityEnable: true
+podAntiAffinityEnable: false

--- a/helm/custom-values/ack-values.yaml
+++ b/helm/custom-values/ack-values.yaml
@@ -218,7 +218,7 @@ licenseKeyDetails:
   # The Bold BI licnece key which you have purchesed.
   licenseKey: ""
 
-# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
@@ -228,7 +228,7 @@ tolerations:
     value: ""
     effect: ""
 
-# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Node affinity ensures that the pods are scheduled into nodes with matching labels.
 # Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
@@ -236,10 +236,10 @@ nodeAffinity:
   operator: ""
   value: ""
 
-# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Pod affinity ensures that the pods are scheduled into nodes with matching pods.
 # Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
-# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods.
 # Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/ack-values.yaml
+++ b/helm/custom-values/ack-values.yaml
@@ -219,7 +219,7 @@ licenseKeyDetails:
   licenseKey: ""
 
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
-# Set this to true if you have use tolerations in your cluster.
+# Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
 tolerations:
@@ -229,7 +229,7 @@ tolerations:
     effect: ""
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
-# Set this to true if you have use Node affinity in your cluster.
+# Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
   key: ""
@@ -237,9 +237,9 @@ nodeAffinity:
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
-# Set this to true if you have use pod Affinity in your cluster.
+# Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
-# Set this to true if you have use pod AntiAffinity in your cluster.
+# Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/ack-values.yaml
+++ b/helm/custom-values/ack-values.yaml
@@ -221,7 +221,7 @@ licenseKeyDetails:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: false 
+tolerationEnable: true 
 tolerations:
   - key: ""
     operator: ""
@@ -230,18 +230,16 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
+nodeAffinityEnable: true
 nodeAffinity:
-  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinity:
-  podAffinityEnable: false
+podAffinityEnable: true
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinity:
-  podAntiAffinityEnable: false
+podAntiAffinityEnable: true

--- a/helm/custom-values/ack-values.yaml
+++ b/helm/custom-values/ack-values.yaml
@@ -217,3 +217,31 @@ licenseKeyDetails:
   
   # The Bold BI licnece key which you have purchesed.
   licenseKey: ""
+
+# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Set this to true if you have use tolerations in your cluster.
+# If you need more than one toleration, you can add tolerations below.
+tolerationEnable: true
+tolerations:
+  - key: ""
+    operator: ""
+    value: ""
+    effect: ""
+
+# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Set this to true if you have use Node affinity in your cluster.
+nodeAffinity:
+  nodeAffinityEnable: true
+  key: ""
+  operator: ""
+  value: ""
+
+# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Set this to true if you have use pod Affinity in your cluster.
+podAffinity:
+  podAffinityEnable: true
+
+# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Set this to true if you have use pod AntiAffinity in your cluster.
+podAntiAffinity:
+  podAntiAffinityEnable: true

--- a/helm/custom-values/ack-values.yaml
+++ b/helm/custom-values/ack-values.yaml
@@ -221,7 +221,7 @@ licenseKeyDetails:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -231,7 +231,7 @@ tolerations:
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
-  nodeAffinityEnable: true
+  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
@@ -239,9 +239,9 @@ nodeAffinity:
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: true
+  podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
-  podAntiAffinityEnable: true
+  podAntiAffinityEnable: false

--- a/helm/custom-values/aks-values.yaml
+++ b/helm/custom-values/aks-values.yaml
@@ -228,21 +228,30 @@ licenseKeyDetails:
   #  The Bold BI licnece key which you have purchesed.
   licenseKey: ""
   
+# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Set this to true if you have use tolerations in your cluster.
+# If you need more than one toleration, you can add tolerations below.
+tolerationEnable: true
 tolerations:
-  tolerationEnable: true
-  key: app
-  operator: Equal
-  value: boldbi
-  effect: NoExecute
+  - key: ""
+    operator: ""
+    value: ""
+    effect: ""
 
+# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
   nodeAffinityEnable: true
-  key: app
-  operator: In
-  value: boldbi
+  key: ""
+  operator: ""
+  value: ""
 
+# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: false
+  podAffinityEnable: true
 
+# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
   podAntiAffinityEnable: true

--- a/helm/custom-values/aks-values.yaml
+++ b/helm/custom-values/aks-values.yaml
@@ -242,13 +242,7 @@ nodeAffinity:
   value: boldbi
 
 podAffinity:
-  podAffinityEnable: true
-  key: app
-  operator: In
-  value: boldbi
+  podAffinityEnable: false
 
 podAntiAffinity:
   podAntiAffinityEnable: true
-  key: app
-  operator: In
-  value: boldbi

--- a/helm/custom-values/aks-values.yaml
+++ b/helm/custom-values/aks-values.yaml
@@ -229,7 +229,7 @@ licenseKeyDetails:
   licenseKey: ""
   
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
-# Set this to true if you have use tolerations in your cluster.
+# Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
 tolerations:
@@ -239,7 +239,7 @@ tolerations:
     effect: ""
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
-# Set this to true if you have use Node affinity in your cluster.
+# Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
   key: ""
@@ -247,9 +247,9 @@ nodeAffinity:
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
-# Set this to true if you have use pod Affinity in your cluster.
+# Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
-# Set this to true if you have use pod AntiAffinity in your cluster.
+# Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/aks-values.yaml
+++ b/helm/custom-values/aks-values.yaml
@@ -227,3 +227,28 @@ licenseKeyDetails:
   
   #  The Bold BI licnece key which you have purchesed.
   licenseKey: ""
+  
+tolerations:
+  tolerationEnable: true
+  key: app
+  operator: Equal
+  value: boldbi
+  effect: NoExecute
+
+nodeAffinity:
+  nodeAffinityEnable: true
+  key: app
+  operator: In
+  value: boldbi
+
+podAffinity:
+  podAffinityEnable: true
+  key: app
+  operator: In
+  value: boldbi
+
+podAntiAffinity:
+  podAntiAffinityEnable: true
+  key: app
+  operator: In
+  value: boldbi

--- a/helm/custom-values/aks-values.yaml
+++ b/helm/custom-values/aks-values.yaml
@@ -228,7 +228,7 @@ licenseKeyDetails:
   #  The Bold BI licnece key which you have purchesed.
   licenseKey: ""
   
-# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
@@ -238,7 +238,7 @@ tolerations:
     value: ""
     effect: ""
 
-# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Node affinity ensures that the pods are scheduled into nodes with matching labels.
 # Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
@@ -246,10 +246,10 @@ nodeAffinity:
   operator: ""
   value: ""
 
-# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Pod affinity ensures that the pods are scheduled into nodes with matching pods.
 # Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
-# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods.
 # Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/aks-values.yaml
+++ b/helm/custom-values/aks-values.yaml
@@ -231,7 +231,7 @@ licenseKeyDetails:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: false
+tolerationEnable: true 
 tolerations:
   - key: ""
     operator: ""
@@ -240,18 +240,16 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
+nodeAffinityEnable: true
 nodeAffinity:
-  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinity:
-  podAffinityEnable: false
+podAffinityEnable: true
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinity:
-  podAntiAffinityEnable: false
+podAntiAffinityEnable: true

--- a/helm/custom-values/aks-values.yaml
+++ b/helm/custom-values/aks-values.yaml
@@ -231,7 +231,7 @@ licenseKeyDetails:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true 
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -240,7 +240,7 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
-nodeAffinityEnable: true
+nodeAffinityEnable: false
 nodeAffinity:
   key: ""
   operator: ""
@@ -248,8 +248,8 @@ nodeAffinity:
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinityEnable: true
+podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinityEnable: true
+podAntiAffinityEnable: false

--- a/helm/custom-values/aks-values.yaml
+++ b/helm/custom-values/aks-values.yaml
@@ -231,7 +231,7 @@ licenseKeyDetails:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true
+tolerationEnable: false
 tolerations:
   - key: ""
     operator: ""
@@ -241,7 +241,7 @@ tolerations:
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
-  nodeAffinityEnable: true
+  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
@@ -249,9 +249,9 @@ nodeAffinity:
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: true
+  podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
-  podAntiAffinityEnable: true
+  podAntiAffinityEnable: false

--- a/helm/custom-values/common-ack-values.yaml
+++ b/helm/custom-values/common-ack-values.yaml
@@ -198,3 +198,31 @@ queryMetricsInDebugFiles:
 ## If the query and query metrics need to be logged in debug files, set this option to true. By default, this option is set to false.
 queryMetricsWithQueryInDebugFiles:
   enable: false
+
+# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Set this to true if you have use tolerations in your cluster.
+# If you need more than one toleration, you can add tolerations below.
+tolerationEnable: true
+tolerations:
+  - key: ""
+    operator: ""
+    value: ""
+    effect: ""
+
+# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Set this to true if you have use Node affinity in your cluster.
+nodeAffinity:
+  nodeAffinityEnable: true
+  key: ""
+  operator: ""
+  value: ""
+
+# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Set this to true if you have use pod Affinity in your cluster.
+podAffinity:
+  podAffinityEnable: true
+
+# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Set this to true if you have use pod AntiAffinity in your cluster.
+podAntiAffinity:
+  podAntiAffinityEnable: true

--- a/helm/custom-values/common-ack-values.yaml
+++ b/helm/custom-values/common-ack-values.yaml
@@ -199,7 +199,7 @@ queryMetricsInDebugFiles:
 queryMetricsWithQueryInDebugFiles:
   enable: false
 
-# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
@@ -209,7 +209,7 @@ tolerations:
     value: ""
     effect: ""
 
-# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Node affinity ensures that the pods are scheduled into nodes with matching labels.
 # Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
@@ -217,10 +217,10 @@ nodeAffinity:
   operator: ""
   value: ""
 
-# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Pod affinity ensures that the pods are scheduled into nodes with matching pods.
 # Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
-# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods.
 # Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/common-ack-values.yaml
+++ b/helm/custom-values/common-ack-values.yaml
@@ -202,7 +202,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true 
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -211,7 +211,7 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
-nodeAffinityEnable: true
+nodeAffinityEnable: false
 nodeAffinity:
   key: ""
   operator: ""
@@ -219,8 +219,8 @@ nodeAffinity:
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinityEnable: true
+podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinityEnable: true
+podAntiAffinityEnable: false

--- a/helm/custom-values/common-ack-values.yaml
+++ b/helm/custom-values/common-ack-values.yaml
@@ -202,7 +202,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: false
+tolerationEnable: true 
 tolerations:
   - key: ""
     operator: ""
@@ -211,18 +211,16 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
+nodeAffinityEnable: true
 nodeAffinity:
-  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinity:
-  podAffinityEnable: false
+podAffinityEnable: true
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinity:
-  podAntiAffinityEnable: false
+podAntiAffinityEnable: true

--- a/helm/custom-values/common-ack-values.yaml
+++ b/helm/custom-values/common-ack-values.yaml
@@ -200,7 +200,7 @@ queryMetricsWithQueryInDebugFiles:
   enable: false
 
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
-# Set this to true if you have use tolerations in your cluster.
+# Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
 tolerations:
@@ -210,7 +210,7 @@ tolerations:
     effect: ""
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
-# Set this to true if you have use Node affinity in your cluster.
+# Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
   key: ""
@@ -218,9 +218,9 @@ nodeAffinity:
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
-# Set this to true if you have use pod Affinity in your cluster.
+# Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
-# Set this to true if you have use pod AntiAffinity in your cluster.
+# Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/common-ack-values.yaml
+++ b/helm/custom-values/common-ack-values.yaml
@@ -202,7 +202,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true
+tolerationEnable: false
 tolerations:
   - key: ""
     operator: ""
@@ -212,7 +212,7 @@ tolerations:
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
-  nodeAffinityEnable: true
+  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
@@ -220,9 +220,9 @@ nodeAffinity:
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: true
+  podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
-  podAntiAffinityEnable: true
+  podAntiAffinityEnable: false

--- a/helm/custom-values/common-aks-values.yaml
+++ b/helm/custom-values/common-aks-values.yaml
@@ -216,7 +216,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true 
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -225,7 +225,7 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
-nodeAffinityEnable: true
+nodeAffinityEnable: false
 nodeAffinity:
   key: ""
   operator: ""
@@ -233,8 +233,8 @@ nodeAffinity:
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinityEnable: true
+podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinityEnable: true
+podAntiAffinityEnable: false

--- a/helm/custom-values/common-aks-values.yaml
+++ b/helm/custom-values/common-aks-values.yaml
@@ -212,3 +212,31 @@ queryMetricsInDebugFiles:
 ## If the query and query metrics need to be logged in debug files, set this option to true. By default, this option is set to false.
 queryMetricsWithQueryInDebugFiles:
   enable: false
+
+# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Set this to true if you have use tolerations in your cluster.
+# If you need more than one toleration, you can add tolerations below.
+tolerationEnable: true
+tolerations:
+  - key: ""
+    operator: ""
+    value: ""
+    effect: ""
+
+# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Set this to true if you have use Node affinity in your cluster.
+nodeAffinity:
+  nodeAffinityEnable: true
+  key: ""
+  operator: ""
+  value: ""
+
+# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Set this to true if you have use pod Affinity in your cluster.
+podAffinity:
+  podAffinityEnable: true
+
+# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Set this to true if you have use pod AntiAffinity in your cluster.
+podAntiAffinity:
+  podAntiAffinityEnable: true

--- a/helm/custom-values/common-aks-values.yaml
+++ b/helm/custom-values/common-aks-values.yaml
@@ -216,7 +216,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true
+tolerationEnable: false
 tolerations:
   - key: ""
     operator: ""
@@ -226,7 +226,7 @@ tolerations:
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
-  nodeAffinityEnable: true
+  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
@@ -234,9 +234,9 @@ nodeAffinity:
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: true
+  podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
-  podAntiAffinityEnable: true
+  podAntiAffinityEnable: false

--- a/helm/custom-values/common-aks-values.yaml
+++ b/helm/custom-values/common-aks-values.yaml
@@ -214,7 +214,7 @@ queryMetricsWithQueryInDebugFiles:
   enable: false
 
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
-# Set this to true if you have use tolerations in your cluster.
+# Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
 tolerations:
@@ -224,7 +224,7 @@ tolerations:
     effect: ""
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
-# Set this to true if you have use Node affinity in your cluster.
+# Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
   key: ""
@@ -232,9 +232,9 @@ nodeAffinity:
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
-# Set this to true if you have use pod Affinity in your cluster.
+# Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
-# Set this to true if you have use pod AntiAffinity in your cluster.
+# Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/common-aks-values.yaml
+++ b/helm/custom-values/common-aks-values.yaml
@@ -213,7 +213,7 @@ queryMetricsInDebugFiles:
 queryMetricsWithQueryInDebugFiles:
   enable: false
 
-# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
@@ -223,7 +223,7 @@ tolerations:
     value: ""
     effect: ""
 
-# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Node affinity ensures that the pods are scheduled into nodes with matching labels.
 # Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
@@ -231,10 +231,10 @@ nodeAffinity:
   operator: ""
   value: ""
 
-# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Pod affinity ensures that the pods are scheduled into nodes with matching pods.
 # Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
-# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods.
 # Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/common-aks-values.yaml
+++ b/helm/custom-values/common-aks-values.yaml
@@ -216,7 +216,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: false
+tolerationEnable: true 
 tolerations:
   - key: ""
     operator: ""
@@ -225,18 +225,16 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
+nodeAffinityEnable: true
 nodeAffinity:
-  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinity:
-  podAffinityEnable: false
+podAffinityEnable: true
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinity:
-  podAntiAffinityEnable: false
+podAntiAffinityEnable: true

--- a/helm/custom-values/common-eks-valuse.yaml
+++ b/helm/custom-values/common-eks-valuse.yaml
@@ -199,7 +199,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true 
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -208,7 +208,7 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
-nodeAffinityEnable: true
+nodeAffinityEnable: false
 nodeAffinity:
   key: ""
   operator: ""
@@ -216,8 +216,8 @@ nodeAffinity:
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinityEnable: true
+podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinityEnable: true
+podAntiAffinityEnable: false

--- a/helm/custom-values/common-eks-valuse.yaml
+++ b/helm/custom-values/common-eks-valuse.yaml
@@ -195,3 +195,31 @@ queryMetricsInDebugFiles:
 ## If the query and query metrics need to be logged in debug files, set this option to true. By default, this option is set to false.
 queryMetricsWithQueryInDebugFiles:
   enable: false
+
+# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Set this to true if you have use tolerations in your cluster.
+# If you need more than one toleration, you can add tolerations below.
+tolerationEnable: true
+tolerations:
+  - key: ""
+    operator: ""
+    value: ""
+    effect: ""
+
+# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Set this to true if you have use Node affinity in your cluster.
+nodeAffinity:
+  nodeAffinityEnable: true
+  key: ""
+  operator: ""
+  value: ""
+
+# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Set this to true if you have use pod Affinity in your cluster.
+podAffinity:
+  podAffinityEnable: true
+
+# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Set this to true if you have use pod AntiAffinity in your cluster.
+podAntiAffinity:
+  podAntiAffinityEnable: true

--- a/helm/custom-values/common-eks-valuse.yaml
+++ b/helm/custom-values/common-eks-valuse.yaml
@@ -197,7 +197,7 @@ queryMetricsWithQueryInDebugFiles:
   enable: false
 
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
-# Set this to true if you have use tolerations in your cluster.
+# Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
 tolerations:
@@ -207,7 +207,7 @@ tolerations:
     effect: ""
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
-# Set this to true if you have use Node affinity in your cluster.
+# Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
   key: ""
@@ -215,9 +215,9 @@ nodeAffinity:
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
-# Set this to true if you have use pod Affinity in your cluster.
+# Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
-# Set this to true if you have use pod AntiAffinity in your cluster.
+# Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/common-eks-valuse.yaml
+++ b/helm/custom-values/common-eks-valuse.yaml
@@ -199,7 +199,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: false
+tolerationEnable: true 
 tolerations:
   - key: ""
     operator: ""
@@ -208,18 +208,16 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
+nodeAffinityEnable: true
 nodeAffinity:
-  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinity:
-  podAffinityEnable: false
+podAffinityEnable: true
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinity:
-  podAntiAffinityEnable: false
+podAntiAffinityEnable: true

--- a/helm/custom-values/common-eks-valuse.yaml
+++ b/helm/custom-values/common-eks-valuse.yaml
@@ -199,7 +199,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true
+tolerationEnable: false
 tolerations:
   - key: ""
     operator: ""
@@ -209,7 +209,7 @@ tolerations:
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
-  nodeAffinityEnable: true
+  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
@@ -217,9 +217,9 @@ nodeAffinity:
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: true
+  podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
-  podAntiAffinityEnable: true
+  podAntiAffinityEnable: false

--- a/helm/custom-values/common-eks-valuse.yaml
+++ b/helm/custom-values/common-eks-valuse.yaml
@@ -196,7 +196,7 @@ queryMetricsInDebugFiles:
 queryMetricsWithQueryInDebugFiles:
   enable: false
 
-# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
@@ -206,7 +206,7 @@ tolerations:
     value: ""
     effect: ""
 
-# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Node affinity ensures that the pods are scheduled into nodes with matching labels.
 # Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
@@ -214,10 +214,10 @@ nodeAffinity:
   operator: ""
   value: ""
 
-# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Pod affinity ensures that the pods are scheduled into nodes with matching pods.
 # Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
-# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods.
 # Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/common-gke-values.yaml
+++ b/helm/custom-values/common-gke-values.yaml
@@ -200,7 +200,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true
+tolerationEnable: false
 tolerations:
   - key: ""
     operator: ""
@@ -210,7 +210,7 @@ tolerations:
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
-  nodeAffinityEnable: true
+  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
@@ -218,9 +218,9 @@ nodeAffinity:
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: true
+  podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
-  podAntiAffinityEnable: true
+  podAntiAffinityEnable: false

--- a/helm/custom-values/common-gke-values.yaml
+++ b/helm/custom-values/common-gke-values.yaml
@@ -196,3 +196,31 @@ queryMetricsInDebugFiles:
 ## If the query and query metrics need to be logged in debug files, set this option to true. By default, this option is set to false.
 queryMetricsWithQueryInDebugFiles:
   enable: false
+
+# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Set this to true if you have use tolerations in your cluster.
+# If you need more than one toleration, you can add tolerations below.
+tolerationEnable: true
+tolerations:
+  - key: ""
+    operator: ""
+    value: ""
+    effect: ""
+
+# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Set this to true if you have use Node affinity in your cluster.
+nodeAffinity:
+  nodeAffinityEnable: true
+  key: ""
+  operator: ""
+  value: ""
+
+# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Set this to true if you have use pod Affinity in your cluster.
+podAffinity:
+  podAffinityEnable: true
+
+# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Set this to true if you have use pod AntiAffinity in your cluster.
+podAntiAffinity:
+  podAntiAffinityEnable: true

--- a/helm/custom-values/common-gke-values.yaml
+++ b/helm/custom-values/common-gke-values.yaml
@@ -200,7 +200,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true 
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -209,7 +209,7 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
-nodeAffinityEnable: true
+nodeAffinityEnable: false
 nodeAffinity:
   key: ""
   operator: ""
@@ -217,8 +217,8 @@ nodeAffinity:
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinityEnable: true
+podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinityEnable: true
+podAntiAffinityEnable: false

--- a/helm/custom-values/common-gke-values.yaml
+++ b/helm/custom-values/common-gke-values.yaml
@@ -200,7 +200,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: false
+tolerationEnable: true 
 tolerations:
   - key: ""
     operator: ""
@@ -209,18 +209,16 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
+nodeAffinityEnable: true
 nodeAffinity:
-  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinity:
-  podAffinityEnable: false
+podAffinityEnable: true
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinity:
-  podAntiAffinityEnable: false
+podAntiAffinityEnable: true

--- a/helm/custom-values/common-gke-values.yaml
+++ b/helm/custom-values/common-gke-values.yaml
@@ -198,7 +198,7 @@ queryMetricsWithQueryInDebugFiles:
   enable: false
 
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
-# Set this to true if you have use tolerations in your cluster.
+# Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
 tolerations:
@@ -208,7 +208,7 @@ tolerations:
     effect: ""
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
-# Set this to true if you have use Node affinity in your cluster.
+# Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
   key: ""
@@ -216,9 +216,9 @@ nodeAffinity:
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
-# Set this to true if you have use pod Affinity in your cluster.
+# Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
-# Set this to true if you have use pod AntiAffinity in your cluster.
+# Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/common-gke-values.yaml
+++ b/helm/custom-values/common-gke-values.yaml
@@ -197,7 +197,7 @@ queryMetricsInDebugFiles:
 queryMetricsWithQueryInDebugFiles:
   enable: false
 
-# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
@@ -207,7 +207,7 @@ tolerations:
     value: ""
     effect: ""
 
-# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Node affinity ensures that the pods are scheduled into nodes with matching labels.
 # Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
@@ -215,10 +215,10 @@ nodeAffinity:
   operator: ""
   value: ""
 
-# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Pod affinity ensures that the pods are scheduled into nodes with matching pods.
 # Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
-# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods.
 # Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/common-oke-values.yaml
+++ b/helm/custom-values/common-oke-values.yaml
@@ -200,7 +200,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true
+tolerationEnable: false
 tolerations:
   - key: ""
     operator: ""
@@ -210,7 +210,7 @@ tolerations:
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
-  nodeAffinityEnable: true
+  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
@@ -218,9 +218,9 @@ nodeAffinity:
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: true
+  podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
-  podAntiAffinityEnable: true
+  podAntiAffinityEnable: false

--- a/helm/custom-values/common-oke-values.yaml
+++ b/helm/custom-values/common-oke-values.yaml
@@ -196,3 +196,31 @@ queryMetricsInDebugFiles:
 ## If the query and query metrics need to be logged in debug files, set this option to true. By default, this option is set to false.
 queryMetricsWithQueryInDebugFiles:
   enable: false
+
+# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Set this to true if you have use tolerations in your cluster.
+# If you need more than one toleration, you can add tolerations below.
+tolerationEnable: true
+tolerations:
+  - key: ""
+    operator: ""
+    value: ""
+    effect: ""
+
+# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Set this to true if you have use Node affinity in your cluster.
+nodeAffinity:
+  nodeAffinityEnable: true
+  key: ""
+  operator: ""
+  value: ""
+
+# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Set this to true if you have use pod Affinity in your cluster.
+podAffinity:
+  podAffinityEnable: true
+
+# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Set this to true if you have use pod AntiAffinity in your cluster.
+podAntiAffinity:
+  podAntiAffinityEnable: true

--- a/helm/custom-values/common-oke-values.yaml
+++ b/helm/custom-values/common-oke-values.yaml
@@ -200,7 +200,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true 
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -209,7 +209,7 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
-nodeAffinityEnable: true
+nodeAffinityEnable: false
 nodeAffinity:
   key: ""
   operator: ""
@@ -217,8 +217,8 @@ nodeAffinity:
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinityEnable: true
+podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinityEnable: true
+podAntiAffinityEnable: false

--- a/helm/custom-values/common-oke-values.yaml
+++ b/helm/custom-values/common-oke-values.yaml
@@ -200,7 +200,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: false
+tolerationEnable: true 
 tolerations:
   - key: ""
     operator: ""
@@ -209,18 +209,16 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
+nodeAffinityEnable: true
 nodeAffinity:
-  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinity:
-  podAffinityEnable: false
+podAffinityEnable: true
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinity:
-  podAntiAffinityEnable: false
+podAntiAffinityEnable: true

--- a/helm/custom-values/common-oke-values.yaml
+++ b/helm/custom-values/common-oke-values.yaml
@@ -198,7 +198,7 @@ queryMetricsWithQueryInDebugFiles:
   enable: false
 
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
-# Set this to true if you have use tolerations in your cluster.
+# Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
 tolerations:
@@ -208,7 +208,7 @@ tolerations:
     effect: ""
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
-# Set this to true if you have use Node affinity in your cluster.
+# Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
   key: ""
@@ -216,9 +216,9 @@ nodeAffinity:
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
-# Set this to true if you have use pod Affinity in your cluster.
+# Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
-# Set this to true if you have use pod AntiAffinity in your cluster.
+# Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/common-oke-values.yaml
+++ b/helm/custom-values/common-oke-values.yaml
@@ -197,7 +197,7 @@ queryMetricsInDebugFiles:
 queryMetricsWithQueryInDebugFiles:
   enable: false
 
-# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
@@ -207,7 +207,7 @@ tolerations:
     value: ""
     effect: ""
 
-# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Node affinity ensures that the pods are scheduled into nodes with matching labels.
 # Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
@@ -215,10 +215,10 @@ nodeAffinity:
   operator: ""
   value: ""
 
-# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Pod affinity ensures that the pods are scheduled into nodes with matching pods.
 # Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
-# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods.
 # Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/eks-values.yaml
+++ b/helm/custom-values/eks-values.yaml
@@ -213,3 +213,31 @@ queryMetricsInDebugFiles:
 ## If the query and query metrics need to be logged in debug files, set this option to true. By default, this option is set to false.
 queryMetricsWithQueryInDebugFiles:
   enable: false
+
+# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Set this to true if you have use tolerations in your cluster.
+# If you need more than one toleration, you can add tolerations below.
+tolerationEnable: true
+tolerations:
+  - key: ""
+    operator: ""
+    value: ""
+    effect: ""
+
+# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Set this to true if you have use Node affinity in your cluster.
+nodeAffinity:
+  nodeAffinityEnable: true
+  key: ""
+  operator: ""
+  value: ""
+
+# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Set this to true if you have use pod Affinity in your cluster.
+podAffinity:
+  podAffinityEnable: true
+
+# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Set this to true if you have use pod AntiAffinity in your cluster.
+podAntiAffinity:
+  podAntiAffinityEnable: true

--- a/helm/custom-values/eks-values.yaml
+++ b/helm/custom-values/eks-values.yaml
@@ -215,7 +215,7 @@ queryMetricsWithQueryInDebugFiles:
   enable: false
 
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
-# Set this to true if you have use tolerations in your cluster.
+# Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
 tolerations:
@@ -225,7 +225,7 @@ tolerations:
     effect: ""
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
-# Set this to true if you have use Node affinity in your cluster.
+# Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
   key: ""
@@ -233,9 +233,9 @@ nodeAffinity:
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
-# Set this to true if you have use pod Affinity in your cluster.
+# Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
-# Set this to true if you have use pod AntiAffinity in your cluster.
+# Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/eks-values.yaml
+++ b/helm/custom-values/eks-values.yaml
@@ -214,7 +214,7 @@ queryMetricsInDebugFiles:
 queryMetricsWithQueryInDebugFiles:
   enable: false
 
-# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
@@ -224,7 +224,7 @@ tolerations:
     value: ""
     effect: ""
 
-# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Node affinity ensures that the pods are scheduled into nodes with matching labels.
 # Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
@@ -232,10 +232,10 @@ nodeAffinity:
   operator: ""
   value: ""
 
-# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Pod affinity ensures that the pods are scheduled into nodes with matching pods.
 # Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
-# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods.
 # Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/eks-values.yaml
+++ b/helm/custom-values/eks-values.yaml
@@ -217,7 +217,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true 
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -226,7 +226,7 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
-nodeAffinityEnable: true
+nodeAffinityEnable: false
 nodeAffinity:
   key: ""
   operator: ""
@@ -234,8 +234,8 @@ nodeAffinity:
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinityEnable: true
+podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinityEnable: true
+podAntiAffinityEnable: false

--- a/helm/custom-values/eks-values.yaml
+++ b/helm/custom-values/eks-values.yaml
@@ -217,7 +217,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: false
+tolerationEnable: true 
 tolerations:
   - key: ""
     operator: ""
@@ -226,18 +226,16 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
+nodeAffinityEnable: true
 nodeAffinity:
-  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinity:
-  podAffinityEnable: false
+podAffinityEnable: true
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinity:
-  podAntiAffinityEnable: false
+podAntiAffinityEnable: true

--- a/helm/custom-values/eks-values.yaml
+++ b/helm/custom-values/eks-values.yaml
@@ -217,7 +217,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true
+tolerationEnable: false
 tolerations:
   - key: ""
     operator: ""
@@ -227,7 +227,7 @@ tolerations:
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
-  nodeAffinityEnable: true
+  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
@@ -235,9 +235,9 @@ nodeAffinity:
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: true
+  podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
-  podAntiAffinityEnable: true
+  podAntiAffinityEnable: false

--- a/helm/custom-values/gke-values.yaml
+++ b/helm/custom-values/gke-values.yaml
@@ -217,7 +217,7 @@ queryMetricsWithQueryInDebugFiles:
   enable: false
 
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
-# Set this to true if you have use tolerations in your cluster.
+# Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
 tolerations:
@@ -227,7 +227,7 @@ tolerations:
     effect: ""
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
-# Set this to true if you have use Node affinity in your cluster.
+# Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
   key: ""
@@ -235,9 +235,9 @@ nodeAffinity:
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
-# Set this to true if you have use pod Affinity in your cluster.
+# Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
-# Set this to true if you have use pod AntiAffinity in your cluster.
+# Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/gke-values.yaml
+++ b/helm/custom-values/gke-values.yaml
@@ -215,3 +215,31 @@ queryMetricsInDebugFiles:
 ## If the query and query metrics need to be logged in debug files, set this option to true. By default, this option is set to false.
 queryMetricsWithQueryInDebugFiles:
   enable: false
+
+# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Set this to true if you have use tolerations in your cluster.
+# If you need more than one toleration, you can add tolerations below.
+tolerationEnable: true
+tolerations:
+  - key: ""
+    operator: ""
+    value: ""
+    effect: ""
+
+# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Set this to true if you have use Node affinity in your cluster.
+nodeAffinity:
+  nodeAffinityEnable: true
+  key: ""
+  operator: ""
+  value: ""
+
+# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Set this to true if you have use pod Affinity in your cluster.
+podAffinity:
+  podAffinityEnable: true
+
+# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Set this to true if you have use pod AntiAffinity in your cluster.
+podAntiAffinity:
+  podAntiAffinityEnable: true

--- a/helm/custom-values/gke-values.yaml
+++ b/helm/custom-values/gke-values.yaml
@@ -219,7 +219,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: false
+tolerationEnable: true 
 tolerations:
   - key: ""
     operator: ""
@@ -228,18 +228,16 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
+nodeAffinityEnable: true
 nodeAffinity:
-  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinity:
-  podAffinityEnable: false
+podAffinityEnable: true
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinity:
-  podAntiAffinityEnable: false
+podAntiAffinityEnable: true

--- a/helm/custom-values/gke-values.yaml
+++ b/helm/custom-values/gke-values.yaml
@@ -219,7 +219,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true 
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -228,7 +228,7 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
-nodeAffinityEnable: true
+nodeAffinityEnable: false
 nodeAffinity:
   key: ""
   operator: ""
@@ -236,8 +236,8 @@ nodeAffinity:
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinityEnable: true
+podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinityEnable: true
+podAntiAffinityEnable: false

--- a/helm/custom-values/gke-values.yaml
+++ b/helm/custom-values/gke-values.yaml
@@ -216,7 +216,7 @@ queryMetricsInDebugFiles:
 queryMetricsWithQueryInDebugFiles:
   enable: false
 
-# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
@@ -226,7 +226,7 @@ tolerations:
     value: ""
     effect: ""
 
-# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Node affinity ensures that the pods are scheduled into nodes with matching labels.
 # Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
@@ -234,10 +234,10 @@ nodeAffinity:
   operator: ""
   value: ""
 
-# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Pod affinity ensures that the pods are scheduled into nodes with matching pods.
 # Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
-# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods.
 # Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/gke-values.yaml
+++ b/helm/custom-values/gke-values.yaml
@@ -219,7 +219,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true
+tolerationEnable: false
 tolerations:
   - key: ""
     operator: ""
@@ -229,7 +229,7 @@ tolerations:
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
-  nodeAffinityEnable: true
+  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
@@ -237,9 +237,9 @@ nodeAffinity:
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: true
+  podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
-  podAntiAffinityEnable: true
+  podAntiAffinityEnable: false

--- a/helm/custom-values/oke-values.yaml
+++ b/helm/custom-values/oke-values.yaml
@@ -219,7 +219,7 @@ licenseKeyDetails:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true 
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -228,7 +228,7 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
-nodeAffinityEnable: true
+nodeAffinityEnable: false
 nodeAffinity:
   key: ""
   operator: ""
@@ -236,8 +236,8 @@ nodeAffinity:
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinityEnable: true
+podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinityEnable: true
+podAntiAffinityEnable: false

--- a/helm/custom-values/oke-values.yaml
+++ b/helm/custom-values/oke-values.yaml
@@ -215,3 +215,31 @@ licenseKeyDetails:
   
   #  The Bold BI licnece key which you have purchesed.
   licenseKey: ""
+
+# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Set this to true if you have use tolerations in your cluster.
+# If you need more than one toleration, you can add tolerations below.
+tolerationEnable: true
+tolerations:
+  - key: ""
+    operator: ""
+    value: ""
+    effect: ""
+
+# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Set this to true if you have use Node affinity in your cluster.
+nodeAffinity:
+  nodeAffinityEnable: true
+  key: ""
+  operator: ""
+  value: ""
+
+# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Set this to true if you have use pod Affinity in your cluster.
+podAffinity:
+  podAffinityEnable: true
+
+# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Set this to true if you have use pod AntiAffinity in your cluster.
+podAntiAffinity:
+  podAntiAffinityEnable: true

--- a/helm/custom-values/oke-values.yaml
+++ b/helm/custom-values/oke-values.yaml
@@ -217,7 +217,7 @@ licenseKeyDetails:
   licenseKey: ""
 
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
-# Set this to true if you have use tolerations in your cluster.
+# Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
 tolerations:
@@ -227,7 +227,7 @@ tolerations:
     effect: ""
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
-# Set this to true if you have use Node affinity in your cluster.
+# Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
   key: ""
@@ -235,9 +235,9 @@ nodeAffinity:
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
-# Set this to true if you have use pod Affinity in your cluster.
+# Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
-# Set this to true if you have use pod AntiAffinity in your cluster.
+# Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/oke-values.yaml
+++ b/helm/custom-values/oke-values.yaml
@@ -219,7 +219,7 @@ licenseKeyDetails:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: false
+tolerationEnable: true 
 tolerations:
   - key: ""
     operator: ""
@@ -228,18 +228,16 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
+nodeAffinityEnable: true
 nodeAffinity:
-  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinity:
-  podAffinityEnable: false
+podAffinityEnable: true
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinity:
-  podAntiAffinityEnable: false
+podAntiAffinityEnable: true

--- a/helm/custom-values/oke-values.yaml
+++ b/helm/custom-values/oke-values.yaml
@@ -216,7 +216,7 @@ licenseKeyDetails:
   #  The Bold BI licnece key which you have purchesed.
   licenseKey: ""
 
-# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
@@ -226,7 +226,7 @@ tolerations:
     value: ""
     effect: ""
 
-# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Node affinity ensures that the pods are scheduled into nodes with matching labels.
 # Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
@@ -234,10 +234,10 @@ nodeAffinity:
   operator: ""
   value: ""
 
-# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Pod affinity ensures that the pods are scheduled into nodes with matching pods.
 # Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
-# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods.
 # Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/oke-values.yaml
+++ b/helm/custom-values/oke-values.yaml
@@ -219,7 +219,7 @@ licenseKeyDetails:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true
+tolerationEnable: false
 tolerations:
   - key: ""
     operator: ""
@@ -229,7 +229,7 @@ tolerations:
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
-  nodeAffinityEnable: true
+  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
@@ -237,9 +237,9 @@ nodeAffinity:
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: true
+  podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
-  podAntiAffinityEnable: true
+  podAntiAffinityEnable: false

--- a/helm/custom-values/values.yaml
+++ b/helm/custom-values/values.yaml
@@ -235,3 +235,31 @@ queryMetricsInDebugFiles:
 ## If the query and query metrics need to be logged in debug files, set this option to true. By default, this option is set to false.
 queryMetricsWithQueryInDebugFiles:
   enable: false
+
+# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Set this to true if you have use tolerations in your cluster.
+# If you need more than one toleration, you can add tolerations below.
+tolerationEnable: true
+tolerations:
+  - key: ""
+    operator: ""
+    value: ""
+    effect: ""
+
+# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Set this to true if you have use Node affinity in your cluster.
+nodeAffinity:
+  nodeAffinityEnable: true
+  key: ""
+  operator: ""
+  value: ""
+
+# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Set this to true if you have use pod Affinity in your cluster.
+podAffinity:
+  podAffinityEnable: true
+
+# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Set this to true if you have use pod AntiAffinity in your cluster.
+podAntiAffinity:
+  podAntiAffinityEnable: true

--- a/helm/custom-values/values.yaml
+++ b/helm/custom-values/values.yaml
@@ -236,7 +236,7 @@ queryMetricsInDebugFiles:
 queryMetricsWithQueryInDebugFiles:
   enable: false
 
-# Tolerations allow the pods to be scheduled onto nodes with matching taints.
+# Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
@@ -246,7 +246,7 @@ tolerations:
     value: ""
     effect: ""
 
-# Node affinity ensures that the pods are scheduled onto nodes with matching labels.
+# Node affinity ensures that the pods are scheduled into nodes with matching labels.
 # Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
@@ -254,10 +254,10 @@ nodeAffinity:
   operator: ""
   value: ""
 
-# Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
+# Pod affinity ensures that the pods are scheduled into nodes with matching pods.
 # Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
-# Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
+# Pod anti-affinity ensures that the pods are not scheduled into nodes with matching pods.
 # Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/values.yaml
+++ b/helm/custom-values/values.yaml
@@ -239,7 +239,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true
+tolerationEnable: false
 tolerations:
   - key: ""
     operator: ""
@@ -249,7 +249,7 @@ tolerations:
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
 nodeAffinity:
-  nodeAffinityEnable: true
+  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
@@ -257,9 +257,9 @@ nodeAffinity:
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
 podAffinity:
-  podAffinityEnable: true
+  podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
 podAntiAffinity:
-  podAntiAffinityEnable: true
+  podAntiAffinityEnable: false

--- a/helm/custom-values/values.yaml
+++ b/helm/custom-values/values.yaml
@@ -237,7 +237,7 @@ queryMetricsWithQueryInDebugFiles:
   enable: false
 
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
-# Set this to true if you have use tolerations in your cluster.
+# Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
 tolerationEnable: false 
 tolerations:
@@ -247,7 +247,7 @@ tolerations:
     effect: ""
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
-# Set this to true if you have use Node affinity in your cluster.
+# Set this to true if you use Node affinity in your cluster.
 nodeAffinityEnable: false
 nodeAffinity:
   key: ""
@@ -255,9 +255,9 @@ nodeAffinity:
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
-# Set this to true if you have use pod Affinity in your cluster.
+# Set this to true if you use pod Affinity in your cluster.
 podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
-# Set this to true if you have use pod AntiAffinity in your cluster.
+# Set this to true if you use pod AntiAffinity in your cluster.
 podAntiAffinityEnable: false

--- a/helm/custom-values/values.yaml
+++ b/helm/custom-values/values.yaml
@@ -239,7 +239,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: true 
+tolerationEnable: false 
 tolerations:
   - key: ""
     operator: ""
@@ -248,7 +248,7 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
-nodeAffinityEnable: true
+nodeAffinityEnable: false
 nodeAffinity:
   key: ""
   operator: ""
@@ -256,8 +256,8 @@ nodeAffinity:
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinityEnable: true
+podAffinityEnable: false
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinityEnable: true
+podAntiAffinityEnable: false

--- a/helm/custom-values/values.yaml
+++ b/helm/custom-values/values.yaml
@@ -239,7 +239,7 @@ queryMetricsWithQueryInDebugFiles:
 # Tolerations allow the pods to be scheduled onto nodes with matching taints.
 # Set this to true if you have use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.
-tolerationEnable: false
+tolerationEnable: true 
 tolerations:
   - key: ""
     operator: ""
@@ -248,18 +248,16 @@ tolerations:
 
 # Node affinity ensures that the pods are scheduled onto nodes with matching labels.
 # Set this to true if you have use Node affinity in your cluster.
+nodeAffinityEnable: true
 nodeAffinity:
-  nodeAffinityEnable: false
   key: ""
   operator: ""
   value: ""
 
 # Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
 # Set this to true if you have use pod Affinity in your cluster.
-podAffinity:
-  podAffinityEnable: false
+podAffinityEnable: true
 
 # Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
 # Set this to true if you have use pod AntiAffinity in your cluster.
-podAntiAffinity:
-  podAntiAffinityEnable: false
+podAntiAffinityEnable: true


### PR DESCRIPTION
### Description:
- Previously, we did not provide tolerations and affinity in the Helm template. However, we now support them.
### Use case:
-  **Tolerations:**  Tolerations allow the pods to be scheduled onto nodes with matching taints.
- **Node affinity:**  Node affinity ensures that the pods are scheduled onto nodes with matching labels.
- **Pod affinity:** Pod affinity ensures that the pods are scheduled onto nodes with matching pods.
- **Pod anti-affinity:** Pod anti-affinity ensures that the pods are not scheduled onto nodes with matching pods.
### testcase: 
- **Objective:** Verify the deployment of Bold-Bi with tolerations and affinity in an AKS cluster.
- **Description:** Ensure that the Helm template for Bold-Bi includes the correct tolerations and affinity configurations and that the deployment is successful in the AKS cluster.