### PR TITLE
377234 - Adding changes for Nginx ingress annotations

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -444,6 +444,20 @@ loadBalancer:
         secretName: tls-secret
 ```
 
+### Nginx Annotation Configuration
+
+By default, the necessary annotations are already included in the Nginx Ingress file. If you need to add annotations based on your specific use case, you can specify them in the values.yaml file in the key:value format. Refer to the example below:
+
+```
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    #cert-manager.io/cluster-issuer: letsencrypt-prod
+    #nginx.ingress.kubernetes.io/rewrite-target: /
+```
+
+This configuration allows you to tailor the behavior of the Nginx Ingress Controller to meet your requirements by adding appropriate annotations.
+
 ## Auto Scaling
 
 By default, autoscaling is enabled in Bold BI, to disable autoscaling, please set `autoscaling.Enabled=false`.

--- a/helm/bold-common/templates/ingress.yaml
+++ b/helm/bold-common/templates/ingress.yaml
@@ -36,6 +36,9 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-max-age: "{{ $.Values.loadBalancer.affinityCookie.affinityCookieExpiration }}"
     {{- end }}
     nginx.ingress.kubernetes.io/proxy-body-size: 200m
+    {{- range $key, $value := .Values.loadBalancer.nginxIngressAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
     {{- if not .Values.subApplication.subPath }}
     nginx.ingress.kubernetes.io/server-snippet: |
       client_max_body_size 200m;
@@ -1814,6 +1817,9 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-max-age: "{{ $.Values.loadBalancer.affinityCookie.affinityCookieExpiration }}"
     {{- end }}
     nginx.ingress.kubernetes.io/proxy-body-size: 200m
+    {{- range $key, $value := .Values.loadBalancer.nginxIngressAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
     nginx.ingress.kubernetes.io/server-snippet: |
       client_max_body_size 200m;
       {{- if eq .Release.Namespace "default" }}

--- a/helm/bold-common/values.yaml
+++ b/helm/bold-common/values.yaml
@@ -78,6 +78,13 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
+
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    #cert-manager.io/cluster-issuer: letsencrypt-prod
+    #nginx.ingress.kubernetes.io/rewrite-target: /
+
   singleHost: 
     secretName: bold-tls
   # multipleHost:

--- a/helm/boldbi/templates/ingress.yaml
+++ b/helm/boldbi/templates/ingress.yaml
@@ -29,6 +29,9 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-max-age: "{{ $.Values.loadBalancer.affinityCookie.affinityCookieExpiration }}"
     {{- end }}
     nginx.ingress.kubernetes.io/proxy-body-size: 200m
+    {{- range $key, $value := .Values.loadBalancer.nginxIngressAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
     nginx.ingress.kubernetes.io/server-snippet: |
       client_max_body_size 200m;
       {{- if eq .Release.Namespace "default" }}

--- a/helm/boldbi/values.yaml
+++ b/helm/boldbi/values.yaml
@@ -54,6 +54,13 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
+
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+    # nginx.ingress.kubernetes.io/rewrite-target: /
+
   singleHost: 
     secretName: bold-tls
   # multipleHost:

--- a/helm/custom-values/Auto-deploy-values.yaml
+++ b/helm/custom-values/Auto-deploy-values.yaml
@@ -131,6 +131,13 @@ loadBalancer:
   # ingressClassName: nginx
   singleHost: 
     secretName: bold-tls
+
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+    # nginx.ingress.kubernetes.io/rewrite-target: /
+
   # multipleHost:
     # hostArray:
       # - hosts: 

--- a/helm/custom-values/Auto-deploy-values.yaml
+++ b/helm/custom-values/Auto-deploy-values.yaml
@@ -129,15 +129,15 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
-  singleHost: 
-    secretName: bold-tls
 
   nginxIngressAnnotations:
     # Enter annotations here for adding annotations in nginx ingress
     # Example:
     # cert-manager.io/cluster-issuer: letsencrypt-prod
     # nginx.ingress.kubernetes.io/rewrite-target: /
-
+    
+  singleHost: 
+    secretName: bold-tls
   # multipleHost:
     # hostArray:
       # - hosts: 

--- a/helm/custom-values/ack-values.yaml
+++ b/helm/custom-values/ack-values.yaml
@@ -33,11 +33,13 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
+
   nginxIngressAnnotations:
     # Enter annotations here for adding annotations in nginx ingress
     # Example:
     # cert-manager.io/cluster-issuer: letsencrypt-prod
     # nginx.ingress.kubernetes.io/rewrite-target: /
+    
   singleHost: 
     secretName: bold-tls
   # multipleHost:

--- a/helm/custom-values/ack-values.yaml
+++ b/helm/custom-values/ack-values.yaml
@@ -33,6 +33,11 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+    # nginx.ingress.kubernetes.io/rewrite-target: /
   singleHost: 
     secretName: bold-tls
   # multipleHost:

--- a/helm/custom-values/aks-values.yaml
+++ b/helm/custom-values/aks-values.yaml
@@ -45,6 +45,13 @@ loadBalancer:
   # ingressClassName: nginx
   singleHost: 
     secretName: bold-tls
+
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+    # nginx.ingress.kubernetes.io/rewrite-target: /
+    
   # multipleHost:
     # hostArray:
       # - hosts: 

--- a/helm/custom-values/aks-values.yaml
+++ b/helm/custom-values/aks-values.yaml
@@ -43,8 +43,6 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
-  singleHost: 
-    secretName: bold-tls
 
   nginxIngressAnnotations:
     # Enter annotations here for adding annotations in nginx ingress
@@ -52,6 +50,8 @@ loadBalancer:
     # cert-manager.io/cluster-issuer: letsencrypt-prod
     # nginx.ingress.kubernetes.io/rewrite-target: /
     
+  singleHost: 
+    secretName: bold-tls   
   # multipleHost:
     # hostArray:
       # - hosts: 

--- a/helm/custom-values/common-ack-values.yaml
+++ b/helm/custom-values/common-ack-values.yaml
@@ -47,6 +47,13 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
+  
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    #cert-manager.io/cluster-issuer: letsencrypt-prod
+    #nginx.ingress.kubernetes.io/rewrite-target: /
+
   singleHost: 
     secretName: bold-tls
   # multipleHost:

--- a/helm/custom-values/common-aks-values.yaml
+++ b/helm/custom-values/common-aks-values.yaml
@@ -61,6 +61,13 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
+
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    #cert-manager.io/cluster-issuer: letsencrypt-prod
+    #nginx.ingress.kubernetes.io/rewrite-target: /
+
   singleHost: 
     secretName: bold-tls
   # multipleHost:

--- a/helm/custom-values/common-eks-valuse.yaml
+++ b/helm/custom-values/common-eks-valuse.yaml
@@ -44,6 +44,13 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
+  
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    #cert-manager.io/cluster-issuer: letsencrypt-prod
+    #nginx.ingress.kubernetes.io/rewrite-target: /
+
   singleHost: 
     secretName: bold-tls
   # multipleHost:

--- a/helm/custom-values/common-gke-values.yaml
+++ b/helm/custom-values/common-gke-values.yaml
@@ -45,6 +45,13 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
+
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    #cert-manager.io/cluster-issuer: letsencrypt-prod
+    #nginx.ingress.kubernetes.io/rewrite-target: /
+
   singleHost: 
     secretName: bold-tls
   # multipleHost:

--- a/helm/custom-values/common-oke-values.yaml
+++ b/helm/custom-values/common-oke-values.yaml
@@ -45,6 +45,13 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
+
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    #cert-manager.io/cluster-issuer: letsencrypt-prod
+    #nginx.ingress.kubernetes.io/rewrite-target: /
+
   singleHost: 
     secretName: bold-tls
   # multipleHost:

--- a/helm/custom-values/eks-values.yaml
+++ b/helm/custom-values/eks-values.yaml
@@ -30,6 +30,13 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
+  
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    #cert-manager.io/cluster-issuer: letsencrypt-prod
+    #nginx.ingress.kubernetes.io/rewrite-target: /
+
   singleHost: 
     secretName: bold-tls
   # multipleHost:

--- a/helm/custom-values/gke-values.yaml
+++ b/helm/custom-values/gke-values.yaml
@@ -31,6 +31,13 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
+  
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    #cert-manager.io/cluster-issuer: letsencrypt-prod
+    #nginx.ingress.kubernetes.io/rewrite-target: /
+
   singleHost: 
     secretName: bold-tls
   # multipleHost:

--- a/helm/custom-values/oke-values.yaml
+++ b/helm/custom-values/oke-values.yaml
@@ -31,6 +31,13 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
+  
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    #cert-manager.io/cluster-issuer: letsencrypt-prod
+    #nginx.ingress.kubernetes.io/rewrite-target: /
+
   singleHost: 
     secretName: bold-tls
   # multipleHost:

--- a/helm/custom-values/values.yaml
+++ b/helm/custom-values/values.yaml
@@ -45,6 +45,13 @@ loadBalancer:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
+  
+  nginxIngressAnnotations:
+    # Enter annotations here for adding annotations in nginx ingress
+    # Example:
+    #cert-manager.io/cluster-issuer: letsencrypt-prod
+    #nginx.ingress.kubernetes.io/rewrite-target: /
+
   singleHost: 
     secretName: bold-tls
   # multipleHost:


### PR DESCRIPTION
To enable the option to add additional annotations in the NGINX Ingress, we have made changes to obtain annotation values from the values.yaml file and pass them to the NGINX annotation section.