### PR TITLE
Existing claim option changes

### DIFF
--- a/helm/boldbi/templates/deployment.yaml
+++ b/helm/boldbi/templates/deployment.yaml
@@ -186,7 +186,11 @@ spec:
       volumes:
       - name: {{ $service.app }}-volume
         persistentVolumeClaim:
-          claimName: {{ $.Values.persistentVolume.name }}-claim
+          {{- if $.Values.persistentVolume.useExistingClaim }}
+          claimName: {{ $.Values.persistentVolume.claimName }}
+          {{- else }}
+          claimName: {{ printf "%s-claim" $.Values.persistentVolume.name }}
+          {{- end }}
           readOnly: false
       - name: log4net-config-volume
         configMap:

--- a/helm/boldbi/templates/pvclaim.yaml
+++ b/helm/boldbi/templates/pvclaim.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.persistentVolume.useExistingClaim }}
 {{- if or (eq .Values.clusterProvider "eks") (eq .Values.clusterProvider "onpremise") ( eq .Values.clusterProvider "aks" ) (and .Values.persistentVolume.oke.blockVolume.blockVolumeEnable (not .Values.persistentVolume.oke.blockVolume.storageClassExists)) }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -202,3 +203,4 @@ spec:
    matchLabels:
      alicloud-pvname: bold-fileserver
  {{- end }}
+{{- end }}

--- a/helm/boldbi/values.yaml
+++ b/helm/boldbi/values.yaml
@@ -70,6 +70,11 @@ persistentVolume:
     serverName: ''
     filePath: ''
 
+  # Set 'useExistingClaim' to 'true' to use an existing PVC or 'false' to create a new PVC.
+  # The 'claimName' should be provided only if 'useExistingClaim' is set to 'true'.
+  useExistingClaim: false
+  claimName: '<Existing-Claim-Name>'
+
 
 image:
   repo: us-docker.pkg.dev/boldbi-294612/boldbi


### PR DESCRIPTION
Made changes to support the existing claim functionality by enabling the use of the existingClaim option. This ensures that no new claims are created when an existing claim is sufficient.