### PR TITLE
Improvement(449810): Switch Default Storage from SMB to NFS and Enable Multi-Namespace Deployment for Bold BI

### DIFF
--- a/helm/bold-common/templates/pvclaim.yaml
+++ b/helm/bold-common/templates/pvclaim.yaml
@@ -165,7 +165,7 @@ spec:
  storageClassName: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }}
  {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
  storageClassName: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.storageClass }}
- {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
+ {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.smb.fileShareName ) }}
  storageClassName: azurefile
  {{- else if eq .Values.clusterProvider "gke" }}
  storageClassName: ""

--- a/helm/bold-common/templates/pvclaim.yaml
+++ b/helm/bold-common/templates/pvclaim.yaml
@@ -1,14 +1,14 @@
 {{- if not .Values.persistentVolume.useExistingClaim }}
-{{- if or (eq .Values.clusterProvider "eks") (eq .Values.clusterProvider "onpremise") ( .Values.persistentVolume.aks.nfs.fileShareName ) (and .Values.persistentVolume.oke.blockVolume.blockVolumeEnable (not .Values.persistentVolume.oke.blockVolume.storageClassExists)) }}
+{{- if or (eq .Values.clusterProvider "eks") (eq .Values.clusterProvider "onpremise") ( .Values.persistentVolume.aks.fileShareName  ) (and .Values.persistentVolume.oke.blockVolume.blockVolumeEnable (not .Values.persistentVolume.oke.blockVolume.storageClassExists)) }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   labels:
     {{- include "boldbi.labels" . | nindent 4 }}
   {{- if eq .Values.clusterProvider "eks" }}
-  name: efs-sc
+  name: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }} 
   {{- else if eq .Values.clusterProvider "aks" }}
-  name: azurefile-csi-nfs 
+  name: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.storageClass }} 
   {{- else if eq .Values.clusterProvider "onpremise" }}
   name: bold-storageclass
   {{- else if and (.Values.persistentVolume.oke.blockVolume.blockVolumeEnable) (.Values.persistentVolume.oke.blockVolume.blockVolumeStorageClass) }}
@@ -48,14 +48,14 @@ parameters:
 {{- end }}
 ---
 {{- end }}
-{{- if and (eq .Values.clusterProvider "aks") (.Values.persistentVolume.aks.fileShareName) (.Values.persistentVolume.aks.azureStorageAccountName) (.Values.persistentVolume.aks.azureStorageAccountKey) }}
+{{- if and (eq .Values.clusterProvider "aks") (.Values.persistentVolume.aks.smb.fileShareName) (.Values.persistentVolume.aks.smb.azureStorageAccountName) (.Values.persistentVolume.aks.smb.azureStorageAccountKey) }}
 apiVersion: v1
 kind: Secret
 metadata:
   labels:
     {{- include "boldbi.labels" . | nindent 4 }}
-  {{- if .Values.persistentVolume.aks.secretName }}
-  name: {{ .Values.persistentVolume.aks.secretName }}
+  {{- if .Values.persistentVolume.aks.smb.secretName }}
+  name: {{ .Values.persistentVolume.aks.smb.secretName }}
   {{- else }}
   name: bold-azure-secret
   {{- end }}
@@ -66,8 +66,8 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  azurestorageaccountname: {{ .Values.persistentVolume.aks.azureStorageAccountName }}
-  azurestorageaccountkey: {{ .Values.persistentVolume.aks.azureStorageAccountKey }}
+  azurestorageaccountname: {{ .Values.persistentVolume.aks.smb.azureStorageAccountName }}
+  azurestorageaccountkey: {{ .Values.persistentVolume.aks.smb.azureStorageAccountKey }}
 ---
 {{- end }}
 {{- if not .Values.persistentVolume.oke.blockVolume.blockVolumeEnable }}
@@ -99,16 +99,16 @@ spec:
  hostPath:
    path: "{{ .Values.persistentVolume.onpremise.hostPath }}"
  {{- else if eq .Values.clusterProvider "eks" }}
- storageClassName: efs-sc
+ storageClassName: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }}
  csi:
    driver: efs.csi.aws.com
    volumeHandle: {{ .Values.persistentVolume.eks.efsFileSystemId }}
- {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.nfs.fileShareName ) }}
- storageClassName: azurefile-csi-nfs
- nfs:
-  path: /{{ .Values.persistentVolume.aks.nfs.fileShareName }}
-  server: {{ .Values.persistentVolume.aks.nfs.hostName }}
  {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
+ storageClassName: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.storageClass }}
+ nfs:
+  path: /{{ .Values.persistentVolume.aks.fileShareName }}
+  server: {{ .Values.persistentVolume.aks.hostName }}
+ {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.smb.fileShareName ) }}
  storageClassName: azurefile
  azureFile:
    {{- if .Values.persistentVolume.aks.secretName }}
@@ -116,7 +116,7 @@ spec:
    {{- else }}
    secretName: bold-azure-secret
    {{- end }}
-   shareName: {{ .Values.persistentVolume.aks.fileShareName }}
+   shareName: {{ .Values.persistentVolume.aks.smb.fileShareName }}
    readOnly: false 
  {{- else if eq .Values.clusterProvider "gke" }}
  nfs:
@@ -162,9 +162,9 @@ spec:
  {{- if eq .Values.clusterProvider "onpremise" }}
  storageClassName: bold-storageclass
  {{- else if eq .Values.clusterProvider "eks" }}
- storageClassName: efs-sc
- {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.nfs.fileShareName ) }}
- storageClassName: azurefile-csi-nfs
+ storageClassName: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }}
+ {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
+ storageClassName: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.storageClass }}
  {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
  storageClassName: azurefile
  {{- else if eq .Values.clusterProvider "gke" }}
@@ -194,4 +194,3 @@ spec:
      alicloud-pvname: bold-fileserver
  {{- end }}
 {{- end }}
-

--- a/helm/bold-common/templates/pvclaim.yaml
+++ b/helm/bold-common/templates/pvclaim.yaml
@@ -1,12 +1,12 @@
 {{- if not .Values.persistentVolume.useExistingClaim }}
-{{- if or (eq .Values.clusterProvider "eks") (eq .Values.clusterProvider "onpremise") ( .Values.persistentVolume.aks.fileShareName  ) (and .Values.persistentVolume.oke.blockVolume.blockVolumeEnable (not .Values.persistentVolume.oke.blockVolume.storageClassExists)) }}
+{{- if or (eq .Values.clusterProvider "eks") (eq .Values.clusterProvider "onpremise") ( .Values.persistentVolume.aks.nfs.fileShareName ) (and .Values.persistentVolume.oke.blockVolume.blockVolumeEnable (not .Values.persistentVolume.oke.blockVolume.storageClassExists)) }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   labels:
     {{- include "boldbi.labels" . | nindent 4 }}
   {{- if eq .Values.clusterProvider "eks" }}
-  name: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }} 
+  name: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }}
   {{- else if eq .Values.clusterProvider "aks" }}
   name: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.storageClass }} 
   {{- else if eq .Values.clusterProvider "onpremise" }}
@@ -48,14 +48,14 @@ parameters:
 {{- end }}
 ---
 {{- end }}
-{{- if and (eq .Values.clusterProvider "aks") (.Values.persistentVolume.aks.smb.fileShareName) (.Values.persistentVolume.aks.smb.azureStorageAccountName) (.Values.persistentVolume.aks.smb.azureStorageAccountKey) }}
+{{- if and (eq .Values.clusterProvider "aks") (.Values.persistentVolume.aks.fileShareName) (.Values.persistentVolume.aks.azureStorageAccountName) (.Values.persistentVolume.aks.azureStorageAccountKey) }}
 apiVersion: v1
 kind: Secret
 metadata:
   labels:
     {{- include "boldbi.labels" . | nindent 4 }}
-  {{- if .Values.persistentVolume.aks.smb.secretName }}
-  name: {{ .Values.persistentVolume.aks.smb.secretName }}
+  {{- if .Values.persistentVolume.aks.secretName }}
+  name: {{ .Values.persistentVolume.aks.secretName }}
   {{- else }}
   name: bold-azure-secret
   {{- end }}
@@ -66,8 +66,8 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  azurestorageaccountname: {{ .Values.persistentVolume.aks.smb.azureStorageAccountName }}
-  azurestorageaccountkey: {{ .Values.persistentVolume.aks.smb.azureStorageAccountKey }}
+  azurestorageaccountname: {{ .Values.persistentVolume.aks.azureStorageAccountName }}
+  azurestorageaccountkey: {{ .Values.persistentVolume.aks.azureStorageAccountKey }}
 ---
 {{- end }}
 {{- if not .Values.persistentVolume.oke.blockVolume.blockVolumeEnable }}
@@ -99,16 +99,16 @@ spec:
  hostPath:
    path: "{{ .Values.persistentVolume.onpremise.hostPath }}"
  {{- else if eq .Values.clusterProvider "eks" }}
- storageClassName: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }}
+ storageClassName: efs-sc
  csi:
    driver: efs.csi.aws.com
    volumeHandle: {{ .Values.persistentVolume.eks.efsFileSystemId }}
- {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
- storageClassName: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.storageClass }}
+ {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.nfs.fileShareName ) }}
+ storageClassName: azurefile-csi-nfs
  nfs:
-  path: /{{ .Values.persistentVolume.aks.fileShareName }}
-  server: {{ .Values.persistentVolume.aks.hostName }}
- {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.smb.fileShareName ) }}
+  path: /{{ .Values.persistentVolume.aks.nfs.fileShareName }}
+  server: {{ .Values.persistentVolume.aks.nfs.hostName }}
+ {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
  storageClassName: azurefile
  azureFile:
    {{- if .Values.persistentVolume.aks.secretName }}
@@ -116,7 +116,7 @@ spec:
    {{- else }}
    secretName: bold-azure-secret
    {{- end }}
-   shareName: {{ .Values.persistentVolume.aks.smb.fileShareName }}
+   shareName: {{ .Values.persistentVolume.aks.fileShareName }}
    readOnly: false 
  {{- else if eq .Values.clusterProvider "gke" }}
  nfs:
@@ -162,10 +162,10 @@ spec:
  {{- if eq .Values.clusterProvider "onpremise" }}
  storageClassName: bold-storageclass
  {{- else if eq .Values.clusterProvider "eks" }}
- storageClassName: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }}
+ storageClassName: efs-sc
+ {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.nfs.fileShareName ) }}
+ storageClassName: azurefile-csi-nfs
  {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
- storageClassName: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.storageClass }}
- {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.smb.fileShareName ) }}
  storageClassName: azurefile
  {{- else if eq .Values.clusterProvider "gke" }}
  storageClassName: ""

--- a/helm/bold-common/values.yaml
+++ b/helm/bold-common/values.yaml
@@ -22,17 +22,7 @@ persistentVolume:
     fileShareIp: ''
   eks:
     efsFileSystemId: ''
-  aks:
-    # If you have an Azure Storage secret you can use the same by mentioning the secret name below. The default name is 'bold-azure-secret'
-    secretName: ''
-    # Mention the Azure file share name.
-    fileShareName: ''
-    # You can ignore the following values if you are using an azure existing secret.
-    # base64 string
-    azureStorageAccountName: ''
-    # base64 string
-    azureStorageAccountKey: ''
-    
+  aks:    
     # Recommended for Linux containers: use NFS file shares for better performance and persistence.
     # NFS is supported only with Azure Premium FileStorage accounts.
     nfs:
@@ -46,6 +36,17 @@ persistentVolume:
       # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
       # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
       storageClass: 'azurefile-csi-nfs'
+    # To configure SMB file share, specify the following values:
+    # If you have an Azure Storage secret you can use the same by mentioning the secret name below. The default name is 'bold-azure-secret'
+    secretName: ''
+    # Mention the Azure file share name.
+    fileShareName: ''
+    # You can ignore the following values if you are using an azure existing secret.
+    # base64 string
+    azureStorageAccountName: ''
+    # base64 string
+    azureStorageAccountKey: ''
+
   oke:
     # Note: You can use only one type of volume at a time - either a filesystem volume or a block volume.
     # For filesystem volumes, specify your volume handle in this format: <FileSystemOCID>:<MountTargetIP>:<path>

--- a/helm/bold-common/values.yaml
+++ b/helm/bold-common/values.yaml
@@ -22,6 +22,10 @@ persistentVolume:
     fileShareIp: ''
   eks:
     efsFileSystemId: ''
+    # storageClass were global resources.
+    # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
+    # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'efs-sc'
+    storageClass: 'efs-sc'
   aks:
     # Recommended for Linux containers: use NFS file shares for better performance and persistence.
     # NFS is supported only with Azure Premium FileStorage accounts.

--- a/helm/bold-common/values.yaml
+++ b/helm/bold-common/values.yaml
@@ -23,24 +23,29 @@ persistentVolume:
   eks:
     efsFileSystemId: ''
   aks:
-    # If you have an Azure Storage secret you can use the same by mentioning the secret name below. The default name is 'bold-azure-secret'
-    secretName: ''
-    # Mention the Azure file share name.
+    # Recommended for Linux containers: use NFS file shares for better performance and persistence.
+    # NFS is supported only with Azure Premium FileStorage accounts.
+    # Format: 'storageaccountname/filesharename' (e.g., premiumstorage1234/boldbi)
     fileShareName: ''
-    # You can ignore the following values if you are using an azure existing secret.
-    # base64 string
-    azureStorageAccountName: ''
-    # base64 string
-    azureStorageAccountKey: ''
-    
-    # To configure persistent volume using NFS fileshare, provide the following values:
-    # Note: The premium storage account of the NFS fileshare must be within the same subscription as the AKS cluster.
-    nfs:
-      # fileshare name as 'storageaccountname/filesharename' Ex:premiumstorage1234/boldbi.
-      fileShareName: ''
 
-      # hostname of the fileshare Ex:premiumstorage1234.file.core.windows.net.
-      hostName: ''
+    # Provide the hostname of the NFS file share.
+    # Example: premiumstorage1234.file.core.windows.net
+    hostName: ''
+    
+    # storageClass were global resources.
+    # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
+    # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
+    storageClass: 'azurefile-csi-nfs'
+
+    smb:
+      # To configure the persistent volume using an SMB file share, provide the following values:
+      fileShareName: ''
+      
+      # Base64-encoded Azure Storage account name
+      azureStorageAccountName: ''
+      
+      # Base64-encoded Azure Storage account key
+      azureStorageAccountKey: ''
   oke:
     # Note: You can use only one type of volume at a time - either a filesystem volume or a block volume.
     # For filesystem volumes, specify your volume handle in this format: <FileSystemOCID>:<MountTargetIP>:<path>

--- a/helm/bold-common/values.yaml
+++ b/helm/bold-common/values.yaml
@@ -22,34 +22,30 @@ persistentVolume:
     fileShareIp: ''
   eks:
     efsFileSystemId: ''
-    # storageClass were global resources.
-    # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
-    # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'efs-sc'
-    storageClass: 'efs-sc'
   aks:
+    # If you have an Azure Storage secret you can use the same by mentioning the secret name below. The default name is 'bold-azure-secret'
+    secretName: ''
+    # Mention the Azure file share name.
+    fileShareName: ''
+    # You can ignore the following values if you are using an azure existing secret.
+    # base64 string
+    azureStorageAccountName: ''
+    # base64 string
+    azureStorageAccountKey: ''
+    
     # Recommended for Linux containers: use NFS file shares for better performance and persistence.
     # NFS is supported only with Azure Premium FileStorage accounts.
-    # Format: 'storageaccountname/filesharename' (e.g., premiumstorage1234/boldbi)
-    fileShareName: ''
-
-    # Provide the hostname of the NFS file share.
-    # Example: premiumstorage1234.file.core.windows.net
-    hostName: ''
-    
-    # storageClass were global resources.
-    # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
-    # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
-    storageClass: 'azurefile-csi-nfs'
-
-    smb:
-      # To configure the persistent volume using an SMB file share, provide the following values:
+    nfs:
+      # fileshare name as 'storageaccountname/filesharename' Ex:premiumstorage1234/boldbi.
       fileShareName: ''
+
+      # hostname of the fileshare Ex:premiumstorage1234.file.core.windows.net.
+      hostName: ''
       
-      # Base64-encoded Azure Storage account name
-      azureStorageAccountName: ''
-      
-      # Base64-encoded Azure Storage account key
-      azureStorageAccountKey: ''
+      # storageClass were global resources.
+      # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
+      # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
+      storageClass: 'azurefile-csi-nfs'
   oke:
     # Note: You can use only one type of volume at a time - either a filesystem volume or a block volume.
     # For filesystem volumes, specify your volume handle in this format: <FileSystemOCID>:<MountTargetIP>:<path>

--- a/helm/boldbi/templates/pvclaim.yaml
+++ b/helm/boldbi/templates/pvclaim.yaml
@@ -165,7 +165,7 @@ spec:
  storageClassName: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }}
  {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
  storageClassName: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.storageClass }}
- {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
+ {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.smb.fileShareName ) }}
  storageClassName: azurefile
  {{- else if eq .Values.clusterProvider "gke" }}
  storageClassName: ""

--- a/helm/boldbi/templates/pvclaim.yaml
+++ b/helm/boldbi/templates/pvclaim.yaml
@@ -116,7 +116,7 @@ spec:
    {{- else }}
    secretName: bold-azure-secret
    {{- end }}
-   shareName: {{ .Values.persistentVolume.aks.fileShareName }}
+   shareName: {{ .Values.persistentVolume.aks.smb.fileShareName }}
    readOnly: false 
  {{- else if eq .Values.clusterProvider "gke" }}
  nfs:

--- a/helm/boldbi/templates/pvclaim.yaml
+++ b/helm/boldbi/templates/pvclaim.yaml
@@ -99,7 +99,7 @@ spec:
  hostPath:
    path: "{{ .Values.persistentVolume.onpremise.hostPath }}"
  {{- else if eq .Values.clusterProvider "eks" }}
- storageClassName: {{ if $sc }}{{ $sc }}{{ else }}efs-sc{{ end }}
+ storageClassName: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }}
  csi:
    driver: efs.csi.aws.com
    volumeHandle: {{ .Values.persistentVolume.eks.efsFileSystemId }}
@@ -162,7 +162,7 @@ spec:
  {{- if eq .Values.clusterProvider "onpremise" }}
  storageClassName: bold-storageclass
  {{- else if eq .Values.clusterProvider "eks" }}
- storageClassName: {{ if $sc }}{{ $sc }}{{ else }}efs-sc{{ end }}
+ storageClassName: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }}
  {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.nfs.fileShareName ) }}
  storageClassName: azurefile-csi-nfs
  {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}

--- a/helm/boldbi/templates/pvclaim.yaml
+++ b/helm/boldbi/templates/pvclaim.yaml
@@ -54,8 +54,8 @@ kind: Secret
 metadata:
   labels:
     {{- include "boldbi.labels" . | nindent 4 }}
-  {{- if .Values.persistentVolume.aks.secretName }}
-  name: {{ .Values.persistentVolume.aks.secretName }}
+  {{- if .Values.persistentVolume.aks.smb.secretName }}
+  name: {{ .Values.persistentVolume.aks.smb.secretName }}
   {{- else }}
   name: bold-azure-secret
   {{- end }}
@@ -66,8 +66,8 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  azurestorageaccountname: {{ .Values.persistentVolume.aks.azureStorageAccountName }}
-  azurestorageaccountkey: {{ .Values.persistentVolume.aks.azureStorageAccountKey }}
+  azurestorageaccountname: {{ .Values.persistentVolume.aks.smb.azureStorageAccountName }}
+  azurestorageaccountkey: {{ .Values.persistentVolume.aks.smb.azureStorageAccountKey }}
 ---
 {{- end }}
 {{- if not .Values.persistentVolume.oke.blockVolume.blockVolumeEnable }}

--- a/helm/boldbi/templates/pvclaim.yaml
+++ b/helm/boldbi/templates/pvclaim.yaml
@@ -1,14 +1,14 @@
 {{- if not .Values.persistentVolume.useExistingClaim }}
-{{- if or (eq .Values.clusterProvider "eks") (eq .Values.clusterProvider "onpremise") ( .Values.persistentVolume.aks.fileShareName  ) (and .Values.persistentVolume.oke.blockVolume.blockVolumeEnable (not .Values.persistentVolume.oke.blockVolume.storageClassExists)) }}
+{{- if or (eq .Values.clusterProvider "eks") (eq .Values.clusterProvider "onpremise") ( .Values.persistentVolume.aks.nfs.fileShareName  ) (and .Values.persistentVolume.oke.blockVolume.blockVolumeEnable (not .Values.persistentVolume.oke.blockVolume.storageClassExists)) }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   labels:
     {{- include "boldbi.labels" . | nindent 4 }}
   {{- if eq .Values.clusterProvider "eks" }}
-  name: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }} 
+  name: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }}
   {{- else if eq .Values.clusterProvider "aks" }}
-  name: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.storageClass }} 
+  name: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.nfs.storageClass }} 
   {{- else if eq .Values.clusterProvider "onpremise" }}
   name: bold-storageclass
   {{- else if and (.Values.persistentVolume.oke.blockVolume.blockVolumeEnable) (.Values.persistentVolume.oke.blockVolume.blockVolumeStorageClass) }}
@@ -48,14 +48,14 @@ parameters:
 {{- end }}
 ---
 {{- end }}
-{{- if and (eq .Values.clusterProvider "aks") (.Values.persistentVolume.aks.smb.fileShareName) (.Values.persistentVolume.aks.smb.azureStorageAccountName) (.Values.persistentVolume.aks.smb.azureStorageAccountKey) }}
+{{- if and (eq .Values.clusterProvider "aks") (.Values.persistentVolume.aks.fileShareName) (.Values.persistentVolume.aks.azureStorageAccountName) (.Values.persistentVolume.aks.azureStorageAccountKey) }}
 apiVersion: v1
 kind: Secret
 metadata:
   labels:
     {{- include "boldbi.labels" . | nindent 4 }}
-  {{- if .Values.persistentVolume.aks.smb.secretName }}
-  name: {{ .Values.persistentVolume.aks.smb.secretName }}
+  {{- if .Values.persistentVolume.aks.secretName }}
+  name: {{ .Values.persistentVolume.aks.secretName }}
   {{- else }}
   name: bold-azure-secret
   {{- end }}
@@ -66,8 +66,8 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  azurestorageaccountname: {{ .Values.persistentVolume.aks.smb.azureStorageAccountName }}
-  azurestorageaccountkey: {{ .Values.persistentVolume.aks.smb.azureStorageAccountKey }}
+  azurestorageaccountname: {{ .Values.persistentVolume.aks.azureStorageAccountName }}
+  azurestorageaccountkey: {{ .Values.persistentVolume.aks.azureStorageAccountKey }}
 ---
 {{- end }}
 {{- if not .Values.persistentVolume.oke.blockVolume.blockVolumeEnable }}
@@ -99,16 +99,16 @@ spec:
  hostPath:
    path: "{{ .Values.persistentVolume.onpremise.hostPath }}"
  {{- else if eq .Values.clusterProvider "eks" }}
- storageClassName: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }}
+ storageClassName: {{ if $sc }}{{ $sc }}{{ else }}efs-sc{{ end }}
  csi:
    driver: efs.csi.aws.com
    volumeHandle: {{ .Values.persistentVolume.eks.efsFileSystemId }}
- {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
- storageClassName: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.storageClass }}
+ {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.nfs.fileShareName ) }}
+ storageClassName: azurefile-csi-nfs
  nfs:
-  path: /{{ .Values.persistentVolume.aks.fileShareName }}
-  server: {{ .Values.persistentVolume.aks.hostName }}
- {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.smb.fileShareName ) }}
+  path: /{{ .Values.persistentVolume.aks.nfs.fileShareName }}
+  server: {{ .Values.persistentVolume.aks.nfs.hostName }}
+ {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
  storageClassName: azurefile
  azureFile:
    {{- if .Values.persistentVolume.aks.secretName }}
@@ -116,7 +116,7 @@ spec:
    {{- else }}
    secretName: bold-azure-secret
    {{- end }}
-   shareName: {{ .Values.persistentVolume.aks.smb.fileShareName }}
+   shareName: {{ .Values.persistentVolume.aks.fileShareName }}
    readOnly: false 
  {{- else if eq .Values.clusterProvider "gke" }}
  nfs:
@@ -162,10 +162,10 @@ spec:
  {{- if eq .Values.clusterProvider "onpremise" }}
  storageClassName: bold-storageclass
  {{- else if eq .Values.clusterProvider "eks" }}
- storageClassName: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }}
+ storageClassName: {{ if $sc }}{{ $sc }}{{ else }}efs-sc{{ end }}
+ {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.nfs.fileShareName ) }}
+ storageClassName: azurefile-csi-nfs
  {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
- storageClassName: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.storageClass }}
- {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.smb.fileShareName ) }}
  storageClassName: azurefile
  {{- else if eq .Values.clusterProvider "gke" }}
  storageClassName: ""

--- a/helm/boldbi/templates/pvclaim.yaml
+++ b/helm/boldbi/templates/pvclaim.yaml
@@ -1,15 +1,14 @@
-{{- $sc := .Values.persistentVolume.storageClass | trim }}
 {{- if not .Values.persistentVolume.useExistingClaim }}
-{{- if or (eq .Values.clusterProvider "eks") (eq .Values.clusterProvider "onpremise") ( .Values.persistentVolume.aks.nfs.fileShareName  ) (and .Values.persistentVolume.oke.blockVolume.blockVolumeEnable (not .Values.persistentVolume.oke.blockVolume.storageClassExists)) }}
+{{- if or (eq .Values.clusterProvider "eks") (eq .Values.clusterProvider "onpremise") ( .Values.persistentVolume.aks.fileShareName  ) (and .Values.persistentVolume.oke.blockVolume.blockVolumeEnable (not .Values.persistentVolume.oke.blockVolume.storageClassExists)) }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   labels:
     {{- include "boldbi.labels" . | nindent 4 }}
   {{- if eq .Values.clusterProvider "eks" }}
-  name: {{ if $sc }}{{ $sc }}{{ else }}efs-sc{{ end }}
+  name: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }} 
   {{- else if eq .Values.clusterProvider "aks" }}
-  name: azurefile-csi-nfs 
+  name: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.storageClass }} 
   {{- else if eq .Values.clusterProvider "onpremise" }}
   name: bold-storageclass
   {{- else if and (.Values.persistentVolume.oke.blockVolume.blockVolumeEnable) (.Values.persistentVolume.oke.blockVolume.blockVolumeStorageClass) }}
@@ -49,7 +48,7 @@ parameters:
 {{- end }}
 ---
 {{- end }}
-{{- if and (eq .Values.clusterProvider "aks") (.Values.persistentVolume.aks.fileShareName) (.Values.persistentVolume.aks.azureStorageAccountName) (.Values.persistentVolume.aks.azureStorageAccountKey) }}
+{{- if and (eq .Values.clusterProvider "aks") (.Values.persistentVolume.aks.smb.fileShareName) (.Values.persistentVolume.aks.smb.azureStorageAccountName) (.Values.persistentVolume.aks.smb.azureStorageAccountKey) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -100,16 +99,16 @@ spec:
  hostPath:
    path: "{{ .Values.persistentVolume.onpremise.hostPath }}"
  {{- else if eq .Values.clusterProvider "eks" }}
- storageClassName: {{ if $sc }}{{ $sc }}{{ else }}efs-sc{{ end }}
+ storageClassName: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }}
  csi:
    driver: efs.csi.aws.com
    volumeHandle: {{ .Values.persistentVolume.eks.efsFileSystemId }}
- {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.nfs.fileShareName ) }}
- storageClassName: azurefile-csi-nfs
- nfs:
-  path: /{{ .Values.persistentVolume.aks.nfs.fileShareName }}
-  server: {{ .Values.persistentVolume.aks.nfs.hostName }}
  {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
+ storageClassName: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.storageClass }}
+ nfs:
+  path: /{{ .Values.persistentVolume.aks.fileShareName }}
+  server: {{ .Values.persistentVolume.aks.hostName }}
+ {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.smb.fileShareName ) }}
  storageClassName: azurefile
  azureFile:
    {{- if .Values.persistentVolume.aks.secretName }}
@@ -163,9 +162,9 @@ spec:
  {{- if eq .Values.clusterProvider "onpremise" }}
  storageClassName: bold-storageclass
  {{- else if eq .Values.clusterProvider "eks" }}
- storageClassName: {{ if $sc }}{{ $sc }}{{ else }}efs-sc{{ end }}
- {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.nfs.fileShareName ) }}
- storageClassName: azurefile-csi-nfs
+ storageClassName: {{ default "efs-sc" .Values.persistentVolume.eks.storageClass }}
+ {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
+ storageClassName: {{ default "azurefile-csi-nfs" .Values.persistentVolume.aks.storageClass }}
  {{- else if and (eq .Values.clusterProvider "aks") ( .Values.persistentVolume.aks.fileShareName ) }}
  storageClassName: azurefile
  {{- else if eq .Values.clusterProvider "gke" }}

--- a/helm/boldbi/values.yaml
+++ b/helm/boldbi/values.yaml
@@ -12,6 +12,9 @@ persistentVolume:
   # Change this name to avoid conflicts with previous Bold BI persistent volumes.
   name: bold-fileserver
   capacity: 3Gi
+  # Provide a value for 'storageClass' only if deploying Bold BI alongside Bold Reports to avoid storage class conflicts.
+  # Otherwise, leave it blank to use the default 'efs-sc' during standalone Bold BI deployment.
+  storageClass: ''
   gke:
     fileShareName: ''
     fileShareIp: ''
@@ -56,29 +59,26 @@ persistentVolume:
       blockVolumeName: ""
 
   aks:
+    fileShareName: ''
+    # base64 string
+    azureStorageAccountName: ''
+    # base64 string
+    azureStorageAccountKey: ''
+    
     # Recommended for Linux containers: use NFS file shares for better performance and persistence.
     # NFS is supported only with Azure Premium FileStorage accounts.
-    # Format: 'storageaccountname/filesharename' (e.g., premiumstorage1234/boldbi)
-    fileShareName: ''
-
-    # Provide the hostname of the NFS file share.
-    # Example: premiumstorage1234.file.core.windows.net
-    hostName: ''
-    
-    # storageClass were global resources.
-    # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
-    # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
-    storageClass: 'azurefile-csi-nfs'
-
-    smb:
-      # To configure the persistent volume using an SMB file share, provide the following values:
+    nfs:
+      # fileshare name as 'storageaccountname/filesharename' Ex:premiumstorage1234/boldbi.
       fileShareName: ''
-      
-      # Base64-encoded Azure Storage account name
-      azureStorageAccountName: ''
-      
-      # Base64-encoded Azure Storage account key
-      azureStorageAccountKey: ''
+
+      # hostname of the fileshare Ex:premiumstorage1234.file.core.windows.net.
+      hostName: ''
+
+      # storageClass were global resources.
+      # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
+      # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
+      storageClass: 'azurefile-csi-nfs'
+
   ack:
     serverName: ''
     filePath: ''

--- a/helm/boldbi/values.yaml
+++ b/helm/boldbi/values.yaml
@@ -12,14 +12,15 @@ persistentVolume:
   # Change this name to avoid conflicts with previous Bold BI persistent volumes.
   name: bold-fileserver
   capacity: 3Gi
-  # Provide a value for 'storageClass' only if deploying Bold BI alongside Bold Reports to avoid storage class conflicts.
-  # Otherwise, leave it blank to use the default 'efs-sc' during standalone Bold BI deployment.
-  storageClass: ''
   gke:
     fileShareName: ''
     fileShareIp: ''
   eks:
     efsFileSystemId: ''
+    # storageClass were global resources.
+    # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
+    # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'efs-sc'
+    storageClass: 'efs-sc'
   oke:
     # Note: You can use only one type of volume at a time - either a filesystem volume or a block volume.
     # For filesystem volumes, specify your volume handle in this format: <FileSystemOCID>:<MountTargetIP>:<path>
@@ -55,20 +56,29 @@ persistentVolume:
       blockVolumeName: ""
 
   aks:
+    # Recommended for Linux containers: use NFS file shares for better performance and persistence.
+    # NFS is supported only with Azure Premium FileStorage accounts.
+    # Format: 'storageaccountname/filesharename' (e.g., premiumstorage1234/boldbi)
     fileShareName: ''
-    # base64 string
-    azureStorageAccountName: ''
-    # base64 string
-    azureStorageAccountKey: ''
-    
-    # To configure persistent volume using NFS fileshare, provide the following values:
-    # Note: The premium storage account of the NFS fileshare must be within the same subscription as the AKS cluster.
-    nfs:
-      # fileshare name as 'storageaccountname/filesharename' Ex:premiumstorage1234/boldbi.
-      fileShareName: ''
 
-      # hostname of the fileshare Ex:premiumstorage1234.file.core.windows.net.
-      hostName: ''
+    # Provide the hostname of the NFS file share.
+    # Example: premiumstorage1234.file.core.windows.net
+    hostName: ''
+    
+    # storageClass were global resources.
+    # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
+    # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
+    storageClass: 'azurefile-csi-nfs'
+
+    smb:
+      # To configure the persistent volume using an SMB file share, provide the following values:
+      fileShareName: ''
+      
+      # Base64-encoded Azure Storage account name
+      azureStorageAccountName: ''
+      
+      # Base64-encoded Azure Storage account key
+      azureStorageAccountKey: ''
   ack:
     serverName: ''
     filePath: ''

--- a/helm/boldbi/values.yaml
+++ b/helm/boldbi/values.yaml
@@ -58,13 +58,7 @@ persistentVolume:
       # Note that the persistent volume must be in an "Available" state.
       blockVolumeName: ""
 
-  aks:
-    fileShareName: ''
-    # base64 string
-    azureStorageAccountName: ''
-    # base64 string
-    azureStorageAccountKey: ''
-    
+  aks:    
     # Recommended for Linux containers: use NFS file shares for better performance and persistence.
     # NFS is supported only with Azure Premium FileStorage accounts.
     nfs:
@@ -78,6 +72,13 @@ persistentVolume:
       # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
       # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
       storageClass: 'azurefile-csi-nfs'
+    # To configure SMB file share, specify the following values:
+    # Mention the Azure file share name.
+    fileShareName: ''
+    # base64 string
+    azureStorageAccountName: ''
+    # base64 string
+    azureStorageAccountKey: ''
 
   ack:
     serverName: ''

--- a/helm/custom-values/aks-values.yaml
+++ b/helm/custom-values/aks-values.yaml
@@ -13,21 +13,29 @@ persistentVolume:
   name: bold-fileserver
   capacity: 3Gi
   aks:
+    # Recommended for Linux containers: use NFS file shares for better performance and persistence.
+    # NFS is supported only with Azure Premium FileStorage accounts.
+    # Format: 'storageaccountname/filesharename' (e.g., premiumstorage1234/boldbi)
     fileShareName: ''
-    # base64 string
-    azureStorageAccountName: ''
-    # base64 string
-    azureStorageAccountKey: ''
 
-    # To configure persistent volume using NFS fileshare, provide the following values:
-    # Note: The premium storage account of the NFS fileshare must be within the same subscription as the AKS cluster.
-    nfs:
-      # fileshare name as 'storageaccountname/filesharename' Ex:premiumstorage1234/boldbi.
-      fileShareName: ''
-
-      # hostname of the fileshare Ex:premiumstorage1234.file.core.windows.net.
-      hostName: ''
+    # Provide the hostname of the NFS file share.
+    # Example: premiumstorage1234.file.core.windows.net
+    hostName: ''
     
+    # storageClass were global resources.
+    # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
+    # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
+    storageClass: 'azurefile-csi-nfs'
+
+    smb:
+      # To configure the persistent volume using an SMB file share, provide the following values:
+      fileShareName: ''
+      
+      # Base64-encoded Azure Storage account name
+      azureStorageAccountName: ''
+      
+      # Base64-encoded Azure Storage account key
+      azureStorageAccountKey: ''    
   #Set 'useExistingClaim' to true to use an existing PersistentVolumeClaim (PVC).
   useExistingClaim: false
   

--- a/helm/custom-values/aks-values.yaml
+++ b/helm/custom-values/aks-values.yaml
@@ -13,29 +13,26 @@ persistentVolume:
   name: bold-fileserver
   capacity: 3Gi
   aks:
+    fileShareName: ''
+    # base64 string
+    azureStorageAccountName: ''
+    # base64 string
+    azureStorageAccountKey: ''
+
     # Recommended for Linux containers: use NFS file shares for better performance and persistence.
     # NFS is supported only with Azure Premium FileStorage accounts.
-    # Format: 'storageaccountname/filesharename' (e.g., premiumstorage1234/boldbi)
-    fileShareName: ''
-
-    # Provide the hostname of the NFS file share.
-    # Example: premiumstorage1234.file.core.windows.net
-    hostName: ''
-    
-    # storageClass were global resources.
-    # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
-    # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
-    storageClass: 'azurefile-csi-nfs'
-
-    smb:
-      # To configure the persistent volume using an SMB file share, provide the following values:
+    nfs:
+      # fileshare name as 'storageaccountname/filesharename' Ex:premiumstorage1234/boldbi.
       fileShareName: ''
-      
-      # Base64-encoded Azure Storage account name
-      azureStorageAccountName: ''
-      
-      # Base64-encoded Azure Storage account key
-      azureStorageAccountKey: ''    
+
+      # hostname of the fileshare Ex:premiumstorage1234.file.core.windows.net.
+      hostName: ''
+
+      # storageClass were global resources.
+      # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
+      # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
+      storageClass: 'azurefile-csi-nfs'
+    
   #Set 'useExistingClaim' to true to use an existing PersistentVolumeClaim (PVC).
   useExistingClaim: false
   

--- a/helm/custom-values/aks-values.yaml
+++ b/helm/custom-values/aks-values.yaml
@@ -13,12 +13,6 @@ persistentVolume:
   name: bold-fileserver
   capacity: 3Gi
   aks:
-    fileShareName: ''
-    # base64 string
-    azureStorageAccountName: ''
-    # base64 string
-    azureStorageAccountKey: ''
-
     # Recommended for Linux containers: use NFS file shares for better performance and persistence.
     # NFS is supported only with Azure Premium FileStorage accounts.
     nfs:
@@ -32,6 +26,14 @@ persistentVolume:
       # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
       # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
       storageClass: 'azurefile-csi-nfs'
+      
+    # To configure SMB file share, specify the following values:
+    # Mention the Azure file share name.
+    fileShareName: ''
+    # base64 string
+    azureStorageAccountName: ''
+    # base64 string
+    azureStorageAccountKey: ''
     
   #Set 'useExistingClaim' to true to use an existing PersistentVolumeClaim (PVC).
   useExistingClaim: false

--- a/helm/custom-values/common-aks-values.yaml
+++ b/helm/custom-values/common-aks-values.yaml
@@ -18,24 +18,29 @@ persistentVolume:
   name: bold-fileserver
   capacity: 3Gi
   aks:
-    # If you have an Azure Storage secret you can use the same by mentioning the secret name below. The default name is 'bold-azure-secret'
-    secretName: ''
-    # Mention the Azure file share name.
+    # Recommended for Linux containers: use NFS file shares for better performance and persistence.
+    # NFS is supported only with Azure Premium FileStorage accounts.
+    # Format: 'storageaccountname/filesharename' (e.g., premiumstorage1234/boldbi)
     fileShareName: ''
-    # You can ignore the following values if you are using an azure existing secret.
-    # base64 string
-    azureStorageAccountName: ''
-    # base64 string
-    azureStorageAccountKey: ''
 
-    # To configure persistent volume using NFS fileshare, provide the following values:
-    # Note: The premium storage account of the NFS fileshare must be within the same subscription as the AKS cluster.
-    nfs:
-      # fileshare name as 'storageaccountname/filesharename' Ex:premiumstorage1234/boldbi.
+    # Provide the hostname of the NFS file share.
+    # Example: premiumstorage1234.file.core.windows.net
+    hostName: ''
+    
+    # storageClass were global resources.
+    # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
+    # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
+    storageClass: 'azurefile-csi-nfs'
+
+    smb:
+      # To configure the persistent volume using an SMB file share, provide the following values:
       fileShareName: ''
-
-      # hostname of the fileshare Ex:premiumstorage1234.file.core.windows.net.
-      hostName: ''
+      
+      # Base64-encoded Azure Storage account name
+      azureStorageAccountName: ''
+      
+      # Base64-encoded Azure Storage account key
+      azureStorageAccountKey: ''
       
   #Set 'useExistingClaim' to true to use an existing PersistentVolumeClaim (PVC).
   useExistingClaim: false

--- a/helm/custom-values/common-aks-values.yaml
+++ b/helm/custom-values/common-aks-values.yaml
@@ -18,16 +18,6 @@ persistentVolume:
   name: bold-fileserver
   capacity: 3Gi
   aks:
-    # If you have an Azure Storage secret you can use the same by mentioning the secret name below. The default name is 'bold-azure-secret'
-    secretName: ''
-    # Mention the Azure file share name.
-    fileShareName: ''
-    # You can ignore the following values if you are using an azure existing secret.
-    # base64 string
-    azureStorageAccountName: ''
-    # base64 string
-    azureStorageAccountKey: ''
-
     # Recommended for Linux containers: use NFS file shares for better performance and persistence.
     # NFS is supported only with Azure Premium FileStorage accounts.
     nfs:
@@ -41,6 +31,17 @@ persistentVolume:
       # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
       # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
       storageClass: 'azurefile-csi-nfs'
+      
+    # To configure SMB file share, specify the following values:
+    # If you have an Azure Storage secret you can use the same by mentioning the secret name below. The default name is 'bold-azure-secret'
+    secretName: ''
+    # Mention the Azure file share name.
+    fileShareName: ''
+    # You can ignore the following values if you are using an azure existing secret.
+    # base64 string
+    azureStorageAccountName: ''
+    # base64 string
+    azureStorageAccountKey: ''
       
   #Set 'useExistingClaim' to true to use an existing PersistentVolumeClaim (PVC).
   useExistingClaim: false

--- a/helm/custom-values/common-aks-values.yaml
+++ b/helm/custom-values/common-aks-values.yaml
@@ -18,29 +18,29 @@ persistentVolume:
   name: bold-fileserver
   capacity: 3Gi
   aks:
+    # If you have an Azure Storage secret you can use the same by mentioning the secret name below. The default name is 'bold-azure-secret'
+    secretName: ''
+    # Mention the Azure file share name.
+    fileShareName: ''
+    # You can ignore the following values if you are using an azure existing secret.
+    # base64 string
+    azureStorageAccountName: ''
+    # base64 string
+    azureStorageAccountKey: ''
+
     # Recommended for Linux containers: use NFS file shares for better performance and persistence.
     # NFS is supported only with Azure Premium FileStorage accounts.
-    # Format: 'storageaccountname/filesharename' (e.g., premiumstorage1234/boldbi)
-    fileShareName: ''
-
-    # Provide the hostname of the NFS file share.
-    # Example: premiumstorage1234.file.core.windows.net
-    hostName: ''
-    
-    # storageClass were global resources.
-    # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
-    # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
-    storageClass: 'azurefile-csi-nfs'
-
-    smb:
-      # To configure the persistent volume using an SMB file share, provide the following values:
+    nfs:
+      # fileshare name as 'storageaccountname/filesharename' Ex:premiumstorage1234/boldbi.
       fileShareName: ''
-      
-      # Base64-encoded Azure Storage account name
-      azureStorageAccountName: ''
-      
-      # Base64-encoded Azure Storage account key
-      azureStorageAccountKey: ''
+
+      # hostname of the fileshare Ex:premiumstorage1234.file.core.windows.net.
+      hostName: ''
+
+      # storageClass were global resources.
+      # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
+      # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'azurefile-csi-nfs'
+      storageClass: 'azurefile-csi-nfs'
       
   #Set 'useExistingClaim' to true to use an existing PersistentVolumeClaim (PVC).
   useExistingClaim: false

--- a/helm/custom-values/common-eks-valuse.yaml
+++ b/helm/custom-values/common-eks-valuse.yaml
@@ -19,6 +19,10 @@ persistentVolume:
   capacity: 3Gi
   eks:
     efsFileSystemId: ''
+    # storageClass were global resources.
+    # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
+    # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'efs-sc'
+    storageClass: 'efs-sc'
   
   #Set 'useExistingClaim' to true to use an existing PersistentVolumeClaim (PVC).
   useExistingClaim: false

--- a/helm/custom-values/eks-values.yaml
+++ b/helm/custom-values/eks-values.yaml
@@ -14,6 +14,7 @@ persistentVolume:
   capacity: 3Gi
   eks:
     efsFileSystemId: ''
+
     # storageClass were global resources.
     # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
     # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'efs-sc'

--- a/helm/custom-values/eks-values.yaml
+++ b/helm/custom-values/eks-values.yaml
@@ -12,12 +12,12 @@ persistentVolume:
   # Change this name to avoid conflicts with previous Bold BI persistent volumes.
   name: bold-fileserver
   capacity: 3Gi
-  # storageClass were global resources.
-  # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
-  # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'efs-sc'
-  storageClass: 'efs-sc'
   eks:
     efsFileSystemId: ''
+    # storageClass were global resources.
+    # so if you already have Bold BI installed in your cluster, then the previous storage class name will conflict with current installation.
+    # Change this name to avoid conflicts with previous Bold BI StorageClass. The default value is 'efs-sc'
+    storageClass: 'efs-sc'
 
   #Set 'useExistingClaim' to true to use an existing PersistentVolumeClaim (PVC).
   useExistingClaim: false

--- a/helm/docs/pre-requisites.md
+++ b/helm/docs/pre-requisites.md
@@ -38,6 +38,18 @@
 
 ### AKS File Storage
 
+For persistent and high-performance storage in Azure Kubernetes Service (AKS), NFS (Network File System) is the preferred option. Since Bold BI containers run on a Linux-based operating system, NFS offers better compatibility and performance compared to SMB. However, SMB-based Azure File Shares are also supported as an alternative if required.
+
+#### NFS
+
+1. Create an NFS file share instance within your premium storage account. Take note of the storage account and file share name, as these will be used to store shared folders for application usage.
+
+2. Identify the hostname in the properties of the file share. Make a note of the hostname as illustrated in the image below.
+
+   ![File Share details](images/nfs-hostname.png)
+
+> **NOTE:** The premium storage account of the NFS fileshare must be within the same subscription as the AKS cluster.
+
 #### SMB
 
 1. Create a File share instance in your storage account and note the File share name to store the shared folders for application usage.
@@ -51,16 +63,6 @@ For encoding the values to base64 please run the following command in powershell
 ```
 
 ![File Share details](images/aks-file-storage.png)
-
-#### NFS
-
-1. Create an NFS file share instance within your premium storage account. Take note of the storage account and file share name, as these will be used to store shared folders for application usage.
-
-2. Identify the hostname in the properties of the file share. Make a note of the hostname as illustrated in the image below.
-
-   ![File Share details](images/nfs-hostname.png)
-
-> **NOTE:** The premium storage account of the NFS fileshare must be within the same subscription as the AKS cluster.
 
 ### ACK File Sotrage
 


### PR DESCRIPTION
This pull request introduces two key changes:

**Default Storage Update:**
The default storage configuration has been changed from **SMB to NFS** to improve compatibility and performance.

**Multi-Namespace Deployment Support:**
The deployment process has been enhanced to support **multiple Bold BI applications within a single Kubernetes** cluster by deploying each instance in a separate namespace.