### PR TITLE
Task(538918): Included support for Upgrade Center service on Bold BI upgrades

### DIFF
--- a/helm/boldbi/templates/deployment.yaml
+++ b/helm/boldbi/templates/deployment.yaml
@@ -196,6 +196,8 @@ spec:
           value: "{{ $.Values.subApplication.subPath | default "boldservices" }}"
         - name: BOLD_SERVICES_USE_SITE_IDENTIFIER
           value: "{{ $.Values.useSiteIdentifier.enable }}" 
+        - name: BOLD_SERVICES_UPGRADECENTER_ENABLE
+          value: "{{ $.Values.upgradeCenter.enabled | default "false" }}"
         {{- else if eq $service.app "bi-dataservice" }}
         - name: AppSettings__CustomSizePDFExport
           value: "{{ $.Values.customSizePdfExport.enable }}"

--- a/helm/boldbi/templates/upgrade-center-deployment.yaml
+++ b/helm/boldbi/templates/upgrade-center-deployment.yaml
@@ -1,0 +1,367 @@
+{{- if .Values.upgradeCenter.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: boldbi-upgrade-center
+{{ include "boldbi.namespace" . | indent 2 }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}_{{ .Chart.Version }}
+    app.kubernetes.io/name: boldbi-upgrade-center
+    app.kubernetes.io/instance: {{ .Release.Name }}
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: boldbi-upgrade-center
+{{ include "boldbi.namespace" . | indent 2 }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}_{{ .Chart.Version }}
+    app.kubernetes.io/name: boldbi-upgrade-center
+    app.kubernetes.io/instance: {{ .Release.Name }}
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: boldbi-upgrade-center
+{{ include "boldbi.namespace" . | indent 2 }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}_{{ .Chart.Version }}
+    app.kubernetes.io/name: boldbi-upgrade-center
+    app.kubernetes.io/instance: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: boldbi-upgrade-center
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: boldbi-upgrade-center
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: boldbi-upgrade-center-config
+{{ include "boldbi.namespace" . | indent 2 }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}_{{ .Chart.Version }}
+    app.kubernetes.io/name: boldbi-upgrade-center
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    {{- end }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  releaseVersionsApiUrl: "https://boldbi-release-api.boldbidemo.com/version/json"
+  idpApi: "http://id-api-service:6001/api"
+  ums: "http://id-ums-service:6002/ums"
+  playwrightRunnerImage: "sivakumar2809/upgrade-center-qa:v3.3"
+  playwrightJobTimeoutSeconds: "9000"
+  playwrightCompletedJobTtlSeconds: "3600"
+  playwrightWorkers: "1"
+  playwrightJobCpuRequest: "1"
+  playwrightJobCpuLimit: "2"
+  playwrightJobMemoryRequest: "2Gi"
+  playwrightJobMemoryLimit: "4Gi"
+  playwrightSharedStateVolumeEnabled: "true"
+  playwrightSharedStateStorageClassName: ""
+  playwrightSharedStateStorageSize: "1Gi"
+  playwrightSharedStateAccessMode: "ReadWriteOnce"
+  playwrightSharedStateMountPath: "/app/playwright-shared-state"
+  playwrightSharedStateFsGroup: "1001"
+  playwrightPodHoldSeconds: "180"
+  playwrightPassRateThreshold: "90"
+  playwrightReportUploadBaseUrl: "http://boldbi-upgrade-center/upgrade-center/api/playwright-reports"
+  playwrightResultUploadBaseUrl: "http://boldbi-upgrade-center/upgrade-center/api/playwright-results"
+  productHealthCheckEnabled: "true"
+  productHealthCheckTimeoutSeconds: "300"
+  productHealthCheckPollSeconds: "10"
+  productHealthCheckRequestTimeoutSeconds: "10"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: boldbi-upgrade-center
+{{ include "boldbi.namespace" . | indent 2 }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}_{{ .Chart.Version }}
+    app.kubernetes.io/name: boldbi-upgrade-center
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    {{- end }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.upgradeCenter.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: boldbi-upgrade-center
+      # app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: boldbi-upgrade-center
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccountName: boldbi-upgrade-center
+      automountServiceAccountToken: true
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecrets }}
+      {{- end }}
+      containers:
+        - name: boldbi-upgrade-center
+          image: "{{ .Values.upgradeCenter.image.repo }}:{{ .Values.upgradeCenter.image.tag }}"
+          imagePullPolicy: {{ .Values.upgradeCenter.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              name: http
+          envFrom:
+            - secretRef:
+                name: boldbi-upgrade-center-playwright
+                optional: true
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              value: "Production"
+            - name: ASPNETCORE_URLS
+              value: "http://+:8080"
+            - name: ASPNETCORE_FORWARDEDHEADERS_ENABLED
+              value: "true"
+            - name: UpgradeCenter__ReleaseVersionsApiUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: releaseVersionsApiUrl
+            - name: UpgradeCenter__Services__IdpApi
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: idpApi
+            - name: UpgradeCenter__Services__Ums
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: ums
+            - name: UpgradeCenter__Playwright__UseKubernetesJob
+              value: "true"
+            - name: UpgradeCenter__Playwright__RunnerImage
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightRunnerImage
+            - name: UpgradeCenter__Playwright__JobTimeoutSeconds
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightJobTimeoutSeconds
+            - name: UpgradeCenter__Playwright__CompletedJobTtlSeconds
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightCompletedJobTtlSeconds
+            - name: UpgradeCenter__Playwright__WorkerCount
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightWorkers
+            - name: UpgradeCenter__Playwright__JobCpuRequest
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightJobCpuRequest
+            - name: UpgradeCenter__Playwright__JobCpuLimit
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightJobCpuLimit
+            - name: UpgradeCenter__Playwright__JobMemoryRequest
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightJobMemoryRequest
+            - name: UpgradeCenter__Playwright__JobMemoryLimit
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightJobMemoryLimit
+            - name: UpgradeCenter__Playwright__SharedStateVolumeEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightSharedStateVolumeEnabled
+            - name: UpgradeCenter__Playwright__SharedStateStorageClassName
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightSharedStateStorageClassName
+            - name: UpgradeCenter__Playwright__SharedStateStorageSize
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightSharedStateStorageSize
+            - name: UpgradeCenter__Playwright__SharedStateAccessMode
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightSharedStateAccessMode
+            - name: UpgradeCenter__Playwright__SharedStateMountPath
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightSharedStateMountPath
+            - name: UpgradeCenter__Playwright__SharedStateFsGroup
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightSharedStateFsGroup
+            - name: PLAYWRIGHT_POD_HOLD_SECONDS
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightPodHoldSeconds
+            - name: UpgradeCenter__Playwright__PassRateThreshold
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightPassRateThreshold
+            - name: UpgradeCenter__Playwright__ReportUploadBaseUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightReportUploadBaseUrl
+            - name: UpgradeCenter__Playwright__ResultUploadBaseUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: playwrightResultUploadBaseUrl
+            - name: UpgradeCenter__ProductHealthCheck__Enabled
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: productHealthCheckEnabled
+            - name: UpgradeCenter__ProductHealthCheck__TimeoutSeconds
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: productHealthCheckTimeoutSeconds
+            - name: UpgradeCenter__ProductHealthCheck__PollSeconds
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: productHealthCheckPollSeconds
+            - name: UpgradeCenter__ProductHealthCheck__RequestTimeoutSeconds
+              valueFrom:
+                configMapKeyRef:
+                  name: boldbi-upgrade-center-config
+                  key: productHealthCheckRequestTimeoutSeconds
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+          readinessProbe:
+            httpGet:
+              path: /upgrade-center/health-check
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /upgrade-center/health-check
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: {{ .Values.upgradeCenter.resources.requests.cpu }}
+              memory: {{ .Values.upgradeCenter.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.upgradeCenter.resources.limits.cpu }}
+              memory: {{ .Values.upgradeCenter.resources.limits.memory }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - mountPath: /app/App_Data
+              name: upgrade-center-volume
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: upgrade-center-volume
+          persistentVolumeClaim:
+            claimName: bold-fileserver-claim
+      {{- if .Values.tolerationEnable }}
+      tolerations:
+      {{- range .Values.tolerations }}
+        - key: {{ .key }}
+          operator: {{ .operator }}
+          value: {{ .value }}
+          effect: {{ .effect }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.nodeAffinityEnable }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: {{ .Values.nodeAffinity.key }}
+                    operator: {{ .Values.nodeAffinity.operator }}
+                    values:
+                      - {{ .Values.nodeAffinity.value }}
+      {{- end }}
+{{- end }}

--- a/helm/boldbi/templates/upgrade-center-ingress.yaml
+++ b/helm/boldbi/templates/upgrade-center-ingress.yaml
@@ -1,0 +1,110 @@
+{{- if and .Values.upgradeCenter.enabled (eq .Values.loadBalancer.type "traefik") }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: boldbi-upgrade-center-trailing-slash
+  {{- include "boldbi.namespace" . | nindent 2 }}
+spec:
+  redirectRegex:
+    regex: ^(https?://[^/]+{{ .Values.upgradeCenter.ingressPath }})$
+    replacement: ${1}/
+    permanent: true
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: boldbi-upgrade-center-route-template
+  {{- include "boldbi.namespace" . | nindent 2 }}
+  annotations:
+    kubernetes.io/ingress.class: {{ default "traefik" .Values.loadBalancer.ingressClassName }}
+spec:
+  {{- if eq (split ":" .Values.appBaseUrl)._0 "https" }}
+  entryPoints:
+    - websecure
+  tls:
+    secretName: {{ .Values.loadBalancer.singleHost.secretName | quote }}
+  {{- else }}
+  entryPoints:
+    - web
+  {{- end }}
+  routes:
+    - kind: Rule
+      match: Host(`in-app-upgrade.boldbidemo.com`) && PathPrefix(`{{ .Values.upgradeCenter.ingressPath }}`)
+      middlewares:
+        - name: body-limit-200m
+        - name: boldbi-upgrade-center-trailing-slash
+      priority: 1000
+      services:
+        - name: boldbi-upgrade-center
+          port: 80
+          serversTransport: long-timeouts-transport
+          sticky:
+            cookie:
+              maxAge: {{ default "600" $.Values.loadBalancer.affinityCookie.affinityCookieExpiration }}
+              name: bold.k8s.pod.id
+{{- else if and .Values.upgradeCenter.enabled (eq .Values.loadBalancer.type "nginx") }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: boldbi-upgrade-center-ingress
+  {{- include "boldbi.namespace" . | nindent 2 }}
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    {{- if .Values.loadBalancer.nginxIngressAnnotations }}
+    {{- range $key, $value := .Values.loadBalancer.nginxIngressAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+spec:
+  {{- if .Values.loadBalancer.singleHost.secretName }}
+  tls:
+    - hosts:
+        - {{ include "boldbi.host" . }}
+      secretName: {{ .Values.loadBalancer.singleHost.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ include "boldbi.host" . }}
+      http:
+        paths:
+          - path: {{ .Values.upgradeCenter.ingressPath }}
+            pathType: Prefix
+            backend:
+              service:
+                name: boldbi-upgrade-center
+                port:
+                  number: {{ .Values.upgradeCenter.service.port }}
+{{- else if and .Values.upgradeCenter.enabled (eq .Values.loadBalancer.type "kong") }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: boldbi-upgrade-center-ingress
+  {{- include "boldbi.namespace" . | nindent 2 }}
+  annotations:
+    kubernetes.io/ingress.class: kong
+    {{- if .Values.loadBalancer.kongIngressAnnotations }}
+    {{- range $key, $value := .Values.loadBalancer.kongIngressAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+spec:
+  {{- if .Values.loadBalancer.singleHost.secretName }}
+  tls:
+    - hosts:
+        - {{ include "boldbi.host" . }}
+      secretName: {{ .Values.loadBalancer.singleHost.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ include "boldbi.host" . }}
+      http:
+        paths:
+          - path: {{ .Values.upgradeCenter.ingressPath }}
+            pathType: Prefix
+            backend:
+              service:
+                name: boldbi-upgrade-center
+                port:
+                  number: {{ .Values.upgradeCenter.service.port }}
+{{- end }}

--- a/helm/boldbi/templates/upgrade-center-secret.yaml
+++ b/helm/boldbi/templates/upgrade-center-secret.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.upgradeCenter.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: boldbi-upgrade-center-playwright
+  {{- include "boldbi.namespace" . | nindent 2 }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}_{{ .Chart.Version }}
+    app.kubernetes.io/name: boldbi-upgrade-center-playwright
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    {{- end }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+stringData:
+  BOLDBI_ADMIN_USERNAME: {{ if .Values.rootUserDetails.email }}{{ .Values.rootUserDetails.email | quote }}{{ else }}{{ .Values.upgradeCenter.secret.BOLDBI_ADMIN_USERNAME | quote }}{{ end }}
+  BOLDBI_ADMIN_PASSWORD: {{ if .Values.rootUserDetails.password }}{{ .Values.rootUserDetails.password | quote }}{{ else }}{{ .Values.upgradeCenter.secret.BOLDBI_ADMIN_PASSWORD | quote }}{{ end }}
+{{- end }}

--- a/helm/boldbi/templates/upgrade-center-service.yaml
+++ b/helm/boldbi/templates/upgrade-center-service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.upgradeCenter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: boldbi-upgrade-center
+  {{- include "boldbi.namespace" . | nindent 2 }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}_{{ .Chart.Version }}
+    app.kubernetes.io/name: boldbi-upgrade-center
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    {{- end }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: boldbi-upgrade-center
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/helm/boldbi/values.yaml
+++ b/helm/boldbi/values.yaml
@@ -396,6 +396,39 @@ licenseKeyDetails:
   # The Bold BI license key that you purchased.
   licenseKey: ""
 
+## Bold BI Upgrade Center Configuration
+upgradeCenter:
+  # Set this to true to enable the Bold BI Upgrade Center service
+  enabled: false
+  # If enabled, provide the Root User administrator credentials (email and password) under rootUserDetails or specify them here.
+  # Note: Credentials provided under rootUserDetails take priority. The Upgrade Center credentials are used only when rootUserDetails is empty.
+  secret:
+    BOLDBI_ADMIN_USERNAME: ""
+    BOLDBI_ADMIN_PASSWORD: ""
+
+  # Upgrade Center image repository and tag
+  image:
+    # repo: us-central1-docker.pkg.dev/boldbi-dev-296107/boldbi/bold-upgrade-center
+    # tag: v1.0.180695
+    repo: sivakumar2809/upgrade-center-ui
+    tag: v5.2
+    pullPolicy: Always
+  
+  # Replica count for Upgrade Center deployment
+  replicaCount: 1
+  
+  # Resource requests and limits for Upgrade Center
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1536Mi
+  
+  # Ingress path prefix for Upgrade Center
+  ingressPath: /upgrade-center
+
 # Tolerations allow the pods to be scheduled into nodes with matching taints.
 # Set this to true if you use tolerations in your cluster.
 # If you need more than one toleration, you can add tolerations below.


### PR DESCRIPTION
The Bold BI Upgrade Center is a UI-driven, in-cluster workflow for orchestrating, validating, and smoke-testing Bold BI upgrades using Playwright. This change introduces the Upgrade Center as an opt-in component of the boldbi Helm chart, with multi-ingress support (Traefik, NGINX, Kong) and feature-flag propagation into the identity stack.

**Changes:**

- Added upgrade-center-deployment.yaml (Deployment, ServiceAccount, Role, RoleBinding, ConfigMap).
- Added upgrade-center-service.yaml (ClusterIP Service, port 80).
- Added upgrade-center-secret.yaml (Playwright admin credentials, with rootUserDetails fallback).
- Added upgrade-center-ingress.yaml (Traefik IngressRoute + middleware; NGINX and Kong Ingress).
- Added upgradeCenter configuration in values.yaml (image, replicas, resources, ingressPath, secret, enable flag).
- Added BOLD_SERVICES_UPGRADECENTER_ENABLE env var to the id-ums container in deployment.yaml.

This change enables the Bold BI Upgrade Center to be deployed and managed within the Kubernetes cluster through the Bold BI Helm chart.